### PR TITLE
github action: update checkout version to v4

### DIFF
--- a/.github/workflows/build_test_latest_c.yml
+++ b/.github/workflows/build_test_latest_c.yml
@@ -26,7 +26,7 @@ jobs:
         python-version: ["3.10"]
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4

--- a/.github/workflows/build_test_source_c.yml
+++ b/.github/workflows/build_test_source_c.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         python-version: ["3.10"]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Upload artifact


### PR DESCRIPTION
github action complains with the following messages. The following actions uses Node.js version which is deprecated and will be forced to run on node20: actions/checkout@v3,
actions/setup-python@v4. For more info:
https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/