### PR TITLE
test mpi4py 3.1.6

### DIFF
--- a/.github/workflows/build_test_latest_c.yml
+++ b/.github/workflows/build_test_latest_c.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Install python dependencies via pip
       run: |
         python -m pip install --upgrade pip
-        pip install numpy cython cftime pytest twine wheel check-manifest mpi4py
+        pip install numpy cython cftime pytest twine wheel check-manifest mpi4py==3.1.6
 
     - name: Install pnetcdf
       run: |


### PR DESCRIPTION
It appears mpi4py 4.0.0 made a change to call MPI large-count APIs.
For example, `MPI.Create_subarray` in python will call
`MPI_Type_create_subarray_c` internally in mpi4py.
See its source codes that implement [MPI.Create_subarray](https://github.com/mpi4py/mpi4py/blob/626b0287211a8429380c46f2e3c41d9655718660/src/mpi4py/MPI.src/Datatype.pyx#L304)

PnetCDF-C 1.13.0 and priors have not supported MPI derived datatypes
constructed from the large-count APIs yet. Thus for the moment, set the
mpi4py version to 3.1.6 for GitHub action tests.

FYI. PnetCDF-C has added the support for large-count datatypes in
its [PnetCDF PR #145](https://github.com/Parallel-NetCDF/PnetCDF/pull/145)