### PR TITLE
Remove print memory footprint from example programs

### DIFF
--- a/examples/collective_write.py
+++ b/examples/collective_write.py
@@ -35,7 +35,6 @@ import sys
 import os
 from mpi4py import MPI
 import pnetcdf
-from pnetcdf import inq_malloc_max_size, inq_malloc_size
 import argparse
 import numpy as np
 import inspect
@@ -69,25 +68,6 @@ def print_info(info_used):
     print("MPI hint: cb_buffer_size  =", info_used.Get("cb_buffer_size"))
     print("MPI hint: striping_factor =", info_used.Get("striping_factor"))
     print("MPI hint: striping_unit   =", info_used.Get("striping_unit"))
-
-def pnetcdf_check_mem_usage(comm):
-    global verbose
-    rank = comm.Get_rank()
-    malloc_size, sum_size = 0, 0
-    # print info about PnetCDF internal malloc usage
-    try:
-        malloc_size = inq_malloc_max_size()
-    except:
-        return 
-    else:
-        sum_size = comm.reduce(malloc_size, MPI.SUM, root=0)
-        if rank == 0 and verbose:
-            print("Maximum heap memory allocated by PnetCDF internally is {} bytes".format(sum_size))
-        # check if there is any PnetCDF internal malloc residue
-        malloc_size = inq_malloc_size()
-        sum_size = comm.reduce(malloc_size, MPI.SUM, root=0)
-        if rank == 0 and sum_size > 0:
-            print("Heap memory allocated by PnetCDF internally has {} bytes yet to be freed".format(sum_size))
 
 def pnetcdf_io(comm, filename, file_format, length):
     global verbose
@@ -210,7 +190,7 @@ def main():
         print("{}: example of file create and open".format(__file__))
     # Run pnetcdf i/o
     pnetcdf_io(comm, filename, file_format, length)
-    pnetcdf_check_mem_usage(comm)
+
     MPI.Finalize()
 
 if __name__ == "__main__":

--- a/examples/create_open.py
+++ b/examples/create_open.py
@@ -22,7 +22,6 @@ import sys
 import os
 from mpi4py import MPI
 import pnetcdf
-from pnetcdf import inq_malloc_max_size, inq_malloc_size
 import argparse
 
 verbose = True
@@ -43,21 +42,6 @@ def parse_help():
             print(help_text)
 
     return help_flag
-
-def pnetcdf_check_mem_usage(comm):
-    global verbose
-    malloc_size, sum_size = 0, 0
-    # print info about PnetCDF internal malloc usage
-    malloc_size = inq_malloc_max_size()
-    sum_size = comm.reduce(malloc_size, MPI.SUM, root=0)
-    if rank == 0 and verbose:
-        print("Maximum heap memory allocated by PnetCDF internally is {} bytes".format(sum_size))
-    # check if there is any PnetCDF internal malloc residue
-    malloc_size = inq_malloc_size()
-    sum_size = comm.reduce(malloc_size, MPI.SUM, root=0)
-    if rank == 0 and sum_size > 0:
-        print("Heap memory allocated by PnetCDF internally has {} bytes yet to be freed".format(sum_size))
-
 
 def main():
     global verbose
@@ -84,7 +68,8 @@ def main():
     f = pnetcdf.File(filename=filename, mode = 'r', comm=comm, info=None)
     # close the file
     f.close()
-    pnetcdf_check_mem_usage(comm)
+
+    MPI.Finalize()
 
 if __name__ == "__main__":
     main()

--- a/examples/fill_mode.py
+++ b/examples/fill_mode.py
@@ -45,7 +45,6 @@ import sys
 import os
 from mpi4py import MPI
 import pnetcdf
-from pnetcdf import inq_malloc_max_size, inq_malloc_size
 import argparse
 import numpy as np
 
@@ -67,25 +66,6 @@ def parse_help():
             print(help_text)
 
     return help_flag
-
-def pnetcdf_check_mem_usage(comm):
-    # global verbose
-    malloc_size, sum_size = 0, 0
-    # print info about PnetCDF internal malloc usage
-    try:
-        malloc_size = inq_malloc_max_size()
-    except:
-        return 
-    else:
-        sum_size = comm.reduce(malloc_size, MPI.SUM, root=0)
-        if rank == 0 and verbose:
-            print("Maximum heap memory allocated by PnetCDF internally is {} bytes".format(sum_size))
-        # check if there is any PnetCDF internal malloc residue
-        malloc_size = inq_malloc_size()
-        sum_size = comm.reduce(malloc_size, MPI.SUM, root=0)
-        if rank == 0 and sum_size > 0:
-            print("Heap memory allocated by PnetCDF internally has {} bytes yet to be freed".format(sum_size))
-
 
 def main():
     NY = 3
@@ -157,7 +137,8 @@ def main():
     # write to the 2nd record
     rec_var.put_var_all(buf, start = starts, count = counts)
     f.close()
-    pnetcdf_check_mem_usage(comm)
+
+    MPI.Finalize()
 
 if __name__ == "__main__":
     main()

--- a/examples/flexible_api.py
+++ b/examples/flexible_api.py
@@ -74,7 +74,6 @@ import sys
 import os
 from mpi4py import MPI
 import pnetcdf
-from pnetcdf import inq_malloc_max_size, inq_malloc_size
 import argparse
 import numpy as np
 import inspect
@@ -102,24 +101,6 @@ def parse_help(comm):
             print(help_text)
 
     return help_flag
-
-def pnetcdf_check_mem_usage(comm):
-    rank = comm.Get_rank()
-    malloc_size, sum_size = 0, 0
-    # print info about PnetCDF internal malloc usage
-    try:
-        malloc_size = inq_malloc_max_size()
-    except:
-        return 
-    else:
-        sum_size = comm.reduce(malloc_size, MPI.SUM, root=0)
-        if rank == 0 and verbose:
-            print("Maximum heap memory allocated by PnetCDF internally is {} bytes".format(sum_size))
-        # check if there is any PnetCDF internal malloc residue
-        malloc_size = inq_malloc_size()
-        sum_size = comm.reduce(malloc_size, MPI.SUM, root=0)
-        if rank == 0 and sum_size > 0:
-            print("Heap memory allocated by PnetCDF internally has {} bytes yet to be freed".format(sum_size))
 
 def main():
     comm = MPI.COMM_WORLD
@@ -238,7 +219,7 @@ def main():
                     print(f"Unexpected get buffer[{i}][{j}]={buf_yx[index]}")
     subarray.Free()
     f.close()
-    pnetcdf_check_mem_usage(comm)
+
     MPI.Finalize()
 
 if __name__ == "__main__":

--- a/examples/get_info.py
+++ b/examples/get_info.py
@@ -37,7 +37,6 @@ import sys
 import os
 from mpi4py import MPI
 import pnetcdf
-from pnetcdf import inq_malloc_max_size, inq_malloc_size
 import argparse
 import numpy as np
 
@@ -59,23 +58,6 @@ def parse_help():
             print(help_text)
 
     return help_flag
-
-def pnetcdf_check_mem_usage(comm):
-    malloc_size, sum_size = 0, 0
-    # print info about PnetCDF internal malloc usage
-    try:
-        malloc_size = inq_malloc_max_size()
-    except:
-        return 
-    else:
-        sum_size = comm.reduce(malloc_size, MPI.SUM, root=0)
-        if rank == 0 and verbose:
-            print("Maximum heap memory allocated by PnetCDF internally is {} bytes".format(sum_size))
-        # check if there is any PnetCDF internal malloc residue
-        malloc_size = inq_malloc_size()
-        sum_size = comm.reduce(malloc_size, MPI.SUM, root=0)
-        if rank == 0 and sum_size > 0:
-            print("Heap memory allocated by PnetCDF internally has {} bytes yet to be freed".format(sum_size))
 
 def print_info(info_used):
     nkeys = info_used.Get_nkeys()
@@ -117,8 +99,6 @@ def main():
     info_used.Free()
     f.close()
 
-    # check PnetCDF library internal memory usage
-    pnetcdf_check_mem_usage(comm)
     MPI.Finalize()
 
 if __name__ == "__main__":

--- a/examples/get_vara.py
+++ b/examples/get_vara.py
@@ -54,7 +54,6 @@ import sys
 import os
 from mpi4py import MPI
 import pnetcdf
-from pnetcdf import inq_malloc_max_size, inq_malloc_size
 import argparse
 import numpy as np
 import inspect
@@ -78,24 +77,6 @@ def parse_help(comm):
             print(help_text)
 
     return help_flag
-
-def pnetcdf_check_mem_usage(comm):
-    rank = comm.Get_rank()
-    malloc_size, sum_size = 0, 0
-    # print info about PnetCDF internal malloc usage
-    try:
-        malloc_size = inq_malloc_max_size()
-    except:
-        return 
-    else:
-        sum_size = comm.reduce(malloc_size, MPI.SUM, root=0)
-        if rank == 0 and verbose:
-            print("Maximum heap memory allocated by PnetCDF internally is {} bytes".format(sum_size))
-        # check if there is any PnetCDF internal malloc residue
-        malloc_size = inq_malloc_size()
-        sum_size = comm.reduce(malloc_size, MPI.SUM, root=0)
-        if rank == 0 and sum_size > 0:
-            print("Heap memory allocated by PnetCDF internally has {} bytes yet to be freed".format(sum_size))
 
 def pnetcdf_io(comm, filename, file_format):
     rank = comm.Get_rank()
@@ -158,7 +139,7 @@ def main():
         print("{}: example of file create and open".format(__file__))
     # Run pnetcdf i/o
     pnetcdf_io(comm, filename, file_format)
-    pnetcdf_check_mem_usage(comm)
+
     MPI.Finalize()
 
 if __name__ == "__main__":

--- a/examples/ghost_cell.py
+++ b/examples/ghost_cell.py
@@ -67,7 +67,6 @@ import sys
 import os
 from mpi4py import MPI
 import pnetcdf
-from pnetcdf import inq_malloc_max_size, inq_malloc_size
 import argparse
 import numpy as np
 import inspect
@@ -91,24 +90,6 @@ def parse_help(comm):
             print(help_text)
 
     return help_flag
-
-def pnetcdf_check_mem_usage(comm):
-    rank = comm.Get_rank()
-    malloc_size, sum_size = 0, 0
-    # print info about PnetCDF internal malloc usage
-    try:
-        malloc_size = inq_malloc_max_size()
-    except:
-        return 
-    else:
-        sum_size = comm.reduce(malloc_size, MPI.SUM, root=0)
-        if rank == 0 and verbose:
-            print("Maximum heap memory allocated by PnetCDF internally is {} bytes".format(sum_size))
-        # check if there is any PnetCDF internal malloc residue
-        malloc_size = inq_malloc_size()
-        sum_size = comm.reduce(malloc_size, MPI.SUM, root=0)
-        if rank == 0 and sum_size > 0:
-            print("Heap memory allocated by PnetCDF internally has {} bytes yet to be freed".format(sum_size))
 
 def pnetcdf_io(comm, filename, file_format, length):
     rank = comm.Get_rank()
@@ -201,7 +182,7 @@ def main():
     # Run pnetcdf i/o
     length = 4 if length <= 0 else length
     pnetcdf_io(comm, filename, file_format, length)
-    pnetcdf_check_mem_usage(comm)
+
     MPI.Finalize()
 
 if __name__ == "__main__":

--- a/examples/global_attribute.py
+++ b/examples/global_attribute.py
@@ -36,7 +36,6 @@ import sys
 import os
 from mpi4py import MPI
 import pnetcdf
-from pnetcdf import inq_malloc_max_size, inq_malloc_size
 import argparse
 import numpy as np
 import inspect
@@ -60,24 +59,6 @@ def parse_help(comm):
             print(help_text)
 
     return help_flag
-
-def pnetcdf_check_mem_usage(comm):
-    rank = comm.Get_rank()
-    malloc_size, sum_size = 0, 0
-    # print info about PnetCDF internal malloc usage
-    try:
-        malloc_size = inq_malloc_max_size()
-    except:
-        return 
-    else:
-        sum_size = comm.reduce(malloc_size, MPI.SUM, root=0)
-        if rank == 0 and verbose:
-            print("Maximum heap memory allocated by PnetCDF internally is {} bytes".format(sum_size))
-        # check if there is any PnetCDF internal malloc residue
-        malloc_size = inq_malloc_size()
-        sum_size = comm.reduce(malloc_size, MPI.SUM, root=0)
-        if rank == 0 and sum_size > 0:
-            print("Heap memory allocated by PnetCDF internally has {} bytes yet to be freed".format(sum_size))
 
 def main():
     global verbose
@@ -148,7 +129,7 @@ def main():
     # Read attribute value
     short_att = f.get_att(att_name)
     f.close()
-    pnetcdf_check_mem_usage(comm)
+
     MPI.Finalize()
 
 if __name__ == "__main__":

--- a/examples/hints.py
+++ b/examples/hints.py
@@ -29,7 +29,6 @@ import sys
 import os
 from mpi4py import MPI
 import pnetcdf
-from pnetcdf import inq_malloc_max_size, inq_malloc_size
 import argparse
 import numpy as np
 
@@ -51,23 +50,6 @@ def parse_help():
             print(help_text)
 
     return help_flag
-
-def pnetcdf_check_mem_usage(comm):
-    malloc_size, sum_size = 0, 0
-    # print info about PnetCDF internal malloc usage
-    try:
-        malloc_size = inq_malloc_max_size()
-    except:
-        return 
-    else:
-        sum_size = comm.reduce(malloc_size, MPI.SUM, root=0)
-        if rank == 0 and verbose:
-            print("Maximum heap memory allocated by PnetCDF internally is {} bytes".format(sum_size))
-        # check if there is any PnetCDF internal malloc residue
-        malloc_size = inq_malloc_size()
-        sum_size = comm.reduce(malloc_size, MPI.SUM, root=0)
-        if rank == 0 and sum_size > 0:
-            print("Heap memory allocated by PnetCDF internally has {} bytes yet to be freed".format(sum_size))
 
 def print_hints(nc_file, nc_var1, nc_var2):
     value = np.zeros(MPI.MAX_INFO_VAL, dtype='c')
@@ -174,8 +156,6 @@ def main():
     info1.Free()
     f.close()
 
-    # check PnetCDF library internal memory usage
-    pnetcdf_check_mem_usage(comm)
     MPI.Finalize()
 
 if __name__ == "__main__":

--- a/examples/nonblocking_write.py
+++ b/examples/nonblocking_write.py
@@ -36,7 +36,6 @@ import sys
 import os
 from mpi4py import MPI
 import pnetcdf
-from pnetcdf import inq_malloc_max_size, inq_malloc_size
 import argparse
 import numpy as np
 import inspect
@@ -70,24 +69,6 @@ def print_info(info_used):
     print("MPI hint: cb_buffer_size  =", info_used.Get("cb_buffer_size"))
     print("MPI hint: striping_factor =", info_used.Get("striping_factor"))
     print("MPI hint: striping_unit   =", info_used.Get("striping_unit"))
-
-def pnetcdf_check_mem_usage(comm):
-    rank = comm.Get_rank()
-    malloc_size, sum_size = 0, 0
-    # print info about PnetCDF internal malloc usage
-    try:
-        malloc_size = inq_malloc_max_size()
-    except:
-        return 
-    else:
-        sum_size = comm.reduce(malloc_size, MPI.SUM, root=0)
-        if rank == 0 and verbose:
-            print("Maximum heap memory allocated by PnetCDF internally is {} bytes".format(sum_size))
-        # check if there is any PnetCDF internal malloc residue
-        malloc_size = inq_malloc_size()
-        sum_size = comm.reduce(malloc_size, MPI.SUM, root=0)
-        if rank == 0 and sum_size > 0:
-            print("Heap memory allocated by PnetCDF internally has {} bytes yet to be freed".format(sum_size))
 
 def pnetcdf_io(comm, filename, file_format, length):
     rank = comm.Get_rank()
@@ -315,8 +296,6 @@ def main():
         print("-------  ------------------  ---------  -----------")
         print(" {:4d}    {:4d} x {:4d} x {:4d} {:8.2f}  {:10.2f}\n".format(nprocs, gsizes[0], gsizes[1], gsizes[2], max_write_timing, write_bw))
 
-
-    pnetcdf_check_mem_usage(comm)
     MPI.Finalize()
 
 if __name__ == "__main__":

--- a/examples/nonblocking_write_def.py
+++ b/examples/nonblocking_write_def.py
@@ -37,7 +37,6 @@ import sys
 import os
 from mpi4py import MPI
 import pnetcdf
-from pnetcdf import inq_malloc_max_size, inq_malloc_size
 import argparse
 import numpy as np
 import inspect
@@ -71,24 +70,6 @@ def print_info(info_used):
     print("MPI hint: cb_buffer_size  =", info_used.Get("cb_buffer_size"))
     print("MPI hint: striping_factor =", info_used.Get("striping_factor"))
     print("MPI hint: striping_unit   =", info_used.Get("striping_unit"))
-
-def pnetcdf_check_mem_usage(comm):
-    rank = comm.Get_rank()
-    malloc_size, sum_size = 0, 0
-    # print info about PnetCDF internal malloc usage
-    try:
-        malloc_size = inq_malloc_max_size()
-    except:
-        return 
-    else:
-        sum_size = comm.reduce(malloc_size, MPI.SUM, root=0)
-        if rank == 0 and verbose:
-            print("Maximum heap memory allocated by PnetCDF internally is {} bytes".format(sum_size))
-        # check if there is any PnetCDF internal malloc residue
-        malloc_size = inq_malloc_size()
-        sum_size = comm.reduce(malloc_size, MPI.SUM, root=0)
-        if rank == 0 and sum_size > 0:
-            print("Heap memory allocated by PnetCDF internally has {} bytes yet to be freed".format(sum_size))
 
 def main():
     comm = MPI.COMM_WORLD
@@ -224,8 +205,6 @@ def main():
         print("-------  ------------------  ---------  -----------")
         print(" {:4d}    {:4d} x {:4d} x {:4d} {:8.2f}  {:10.2f}\n".format(nprocs, gsizes[0], gsizes[1], gsizes[2], max_write_timing, write_bw))
 
-
-    pnetcdf_check_mem_usage(comm)
     MPI.Finalize()
 
 if __name__ == "__main__":

--- a/examples/put_vara.py
+++ b/examples/put_vara.py
@@ -57,7 +57,6 @@ import sys
 import os
 from mpi4py import MPI
 import pnetcdf
-from pnetcdf import inq_malloc_max_size, inq_malloc_size
 import argparse
 import numpy as np
 import inspect
@@ -83,24 +82,6 @@ def parse_help(comm):
             print(help_text)
 
     return help_flag
-
-def pnetcdf_check_mem_usage(comm):
-    rank = comm.Get_rank()
-    malloc_size, sum_size = 0, 0
-    # print info about PnetCDF internal malloc usage
-    try:
-        malloc_size = inq_malloc_max_size()
-    except:
-        return 
-    else:
-        sum_size = comm.reduce(malloc_size, MPI.SUM, root=0)
-        if rank == 0 and verbose:
-            print("Maximum heap memory allocated by PnetCDF internally is {} bytes".format(sum_size))
-        # check if there is any PnetCDF internal malloc residue
-        malloc_size = inq_malloc_size()
-        sum_size = comm.reduce(malloc_size, MPI.SUM, root=0)
-        if rank == 0 and sum_size > 0:
-            print("Heap memory allocated by PnetCDF internally has {} bytes yet to be freed".format(sum_size))
 
 def pnetcdf_io(comm, filename, file_format):
     rank = comm.Get_rank()
@@ -175,7 +156,7 @@ def main():
         print("{}: example of file create and open".format(__file__))
     # Run pnetcdf i/o
     pnetcdf_io(comm, filename, file_format)
-    pnetcdf_check_mem_usage(comm)
+
     MPI.Finalize()
 
 if __name__ == "__main__":

--- a/examples/put_varn_int.py
+++ b/examples/put_varn_int.py
@@ -43,7 +43,6 @@ import sys
 import os
 from mpi4py import MPI
 import pnetcdf
-from pnetcdf import inq_malloc_max_size, inq_malloc_size
 import argparse
 import numpy as np
 import inspect
@@ -69,25 +68,6 @@ def parse_help(comm):
             print(help_text)
 
     return help_flag
-
-def pnetcdf_check_mem_usage(comm):
-    rank = comm.Get_rank()
-    malloc_size, sum_size = 0, 0
-    # print info about PnetCDF internal malloc usage
-    try:
-        malloc_size = inq_malloc_max_size()
-    except:
-        return 
-    else:
-        sum_size = comm.reduce(malloc_size, MPI.SUM, root=0)
-        if rank == 0 and verbose:
-            print("Maximum heap memory allocated by PnetCDF internally is {} bytes".format(sum_size))
-        # check if there is any PnetCDF internal malloc residue
-        malloc_size = inq_malloc_size()
-        sum_size = comm.reduce(malloc_size, MPI.SUM, root=0)
-        if rank == 0 and sum_size > 0:
-            print("Heap memory allocated by PnetCDF internally has {} bytes yet to be freed".format(sum_size))
-
 
 def main():
     comm = MPI.COMM_WORLD
@@ -196,7 +176,6 @@ def main():
     v.put_var_all(buffer, start = starts, count = counts, num = num_reqs)
     f.close()
 
-    pnetcdf_check_mem_usage(comm)
     MPI.Finalize()
 
 if __name__ == "__main__":

--- a/examples/transpose.py
+++ b/examples/transpose.py
@@ -32,7 +32,6 @@ import sys
 import os
 from mpi4py import MPI
 import pnetcdf
-from pnetcdf import inq_malloc_max_size, inq_malloc_size
 import argparse
 import numpy as np
 import inspect
@@ -59,24 +58,6 @@ def parse_help(comm):
             print(help_text)
 
     return help_flag
-
-def pnetcdf_check_mem_usage(comm):
-    rank = comm.Get_rank()
-    malloc_size, sum_size = 0, 0
-    # print info about PnetCDF internal malloc usage
-    try:
-        malloc_size = inq_malloc_max_size()
-    except:
-        return 
-    else:
-        sum_size = comm.reduce(malloc_size, MPI.SUM, root=0)
-        if rank == 0 and verbose:
-            print("Maximum heap memory allocated by PnetCDF internally is {} bytes".format(sum_size))
-        # check if there is any PnetCDF internal malloc residue
-        malloc_size = inq_malloc_size()
-        sum_size = comm.reduce(malloc_size, MPI.SUM, root=0)
-        if rank == 0 and sum_size > 0:
-            print("Heap memory allocated by PnetCDF internally has {} bytes yet to be freed".format(sum_size))
 
 def pnetcdf_io(comm, filename, file_format, length):
 
@@ -223,7 +204,7 @@ def main():
         print("{}: example of file create and open".format(__file__))
     # Run pnetcdf i/o
     pnetcdf_io(comm, filename, file_format, length)
-    pnetcdf_check_mem_usage(comm)
+
     MPI.Finalize()
 
 if __name__ == "__main__":

--- a/examples/transpose2D.py
+++ b/examples/transpose2D.py
@@ -54,7 +54,6 @@ import sys
 import os
 from mpi4py import MPI
 import pnetcdf
-from pnetcdf import inq_malloc_max_size, inq_malloc_size
 import argparse
 import numpy as np
 import inspect
@@ -81,24 +80,6 @@ def parse_help(comm):
             print(help_text)
 
     return help_flag
-
-def pnetcdf_check_mem_usage(comm):
-    rank = comm.Get_rank()
-    malloc_size, sum_size = 0, 0
-    # print info about PnetCDF internal malloc usage
-    try:
-        malloc_size = inq_malloc_max_size()
-    except:
-        return 
-    else:
-        sum_size = comm.reduce(malloc_size, MPI.SUM, root=0)
-        if rank == 0 and verbose:
-            print("Maximum heap memory allocated by PnetCDF internally is {} bytes".format(sum_size))
-        # check if there is any PnetCDF internal malloc residue
-        malloc_size = inq_malloc_size()
-        sum_size = comm.reduce(malloc_size, MPI.SUM, root=0)
-        if rank == 0 and sum_size > 0:
-            print("Heap memory allocated by PnetCDF internally has {} bytes yet to be freed".format(sum_size))
 
 def pnetcdf_io(comm, filename, file_format, length):
 
@@ -208,7 +189,7 @@ def main():
         print("{}: example of file create and open".format(__file__))
     # Run pnetcdf i/o
     pnetcdf_io(comm, filename, file_format, length)
-    pnetcdf_check_mem_usage(comm)
+
     MPI.Finalize()
 
 if __name__ == "__main__":


### PR DESCRIPTION
Printing memory footprints is not an essential component of PnetCDF-Python. Additionally, PnetCDF-C may not be configured with '--enable-profiling'. In this case, calling memory footprint utility APIs will return NC_ENOTENABLED.