### PR TITLE
fix example program descriptions

### DIFF
--- a/examples/collective_write.py
+++ b/examples/collective_write.py
@@ -187,7 +187,8 @@ def main():
             length = int(args.l)
     filename = args.dir
     if verbose and rank == 0:
-        print("{}: example of file create and open".format(__file__))
+        print("{}: example of collective writes".format(os.path.basename(__file__)))
+
     # Run pnetcdf i/o
     pnetcdf_io(comm, filename, file_format, length)
 

--- a/examples/create_open.py
+++ b/examples/create_open.py
@@ -59,7 +59,8 @@ def main():
         verbose = False
     filename = args.dir
     if verbose and rank == 0:
-        print("{}: example of file create and open".format(__file__))
+        print("{}: example of file create and open".format(os.path.basename(__file__)))
+
     # create a new file using "w" mode
     f = pnetcdf.File(filename=filename, mode = 'w', comm=comm, info=None)
     # close the file

--- a/examples/fill_mode.py
+++ b/examples/fill_mode.py
@@ -87,7 +87,8 @@ def main():
         verbose = False
     filename = args.dir
     if verbose and rank == 0:
-        print("{}: example of file create and open".format(__file__))
+        print("{}: example of setting fill mode".format(os.path.basename(__file__)))
+
     # create a new file using "w" mode
     f = pnetcdf.File(filename=filename, mode = 'w', comm=comm, info=None)
     # the global array is NY * (NX * nprocs)

--- a/examples/flexible_api.py
+++ b/examples/flexible_api.py
@@ -130,7 +130,8 @@ def main():
         file_format = kind_dict[args.k]
     filename = args.dir
     if verbose and rank == 0:
-        print("{}: example of file create and open".format(__file__))
+        print("{}: example of using flexible APIs".format(os.path.basename(__file__)))
+
 
     # Create the file
     f = pnetcdf.File(filename=filename, mode = 'w', format = file_format, comm=comm, info=None)

--- a/examples/get_info.py
+++ b/examples/get_info.py
@@ -87,7 +87,8 @@ def main():
         verbose = False
     filename = args.dir
     if verbose and rank == 0:
-        print("{}: example of file create and open".format(__file__))
+        print("{}: example of getting MPI-IO hints".format(os.path.basename(__file__)))
+
     # create a new file using "w" mode
     f = pnetcdf.File(filename=filename, mode = 'w', file_format = "64BIT_DATA", comm=comm, info=None)
     # exit the define mode

--- a/examples/get_vara.py
+++ b/examples/get_vara.py
@@ -136,7 +136,8 @@ def main():
         file_format = kind_dict[args.k]
     filename = args.dir
     if verbose and rank == 0:
-        print("{}: example of file create and open".format(__file__))
+        print("{}: example of reading subarray".format(os.path.basename(__file__)))
+
     # Run pnetcdf i/o
     pnetcdf_io(comm, filename, file_format)
 

--- a/examples/ghost_cell.py
+++ b/examples/ghost_cell.py
@@ -178,7 +178,8 @@ def main():
         length = int(args.l)
     filename = args.dir
     if verbose and rank == 0:
-        print("{}: example of file create and open".format(__file__))
+        print("{}: example of using buffers with ghost cells".format(os.path.basename(__file__)))
+
     # Run pnetcdf i/o
     length = 4 if length <= 0 else length
     pnetcdf_io(comm, filename, file_format, length)

--- a/examples/global_attribute.py
+++ b/examples/global_attribute.py
@@ -87,7 +87,8 @@ def main():
         file_format = kind_dict[args.k]
     filename = args.dir
     if verbose and rank == 0:
-        print("{}: example of file create and open".format(__file__))
+        print("{}: example of put/get global attributes".format(os.path.basename(__file__)))
+
     # Run pnetcdf i/o
 
     # Create the file

--- a/examples/hints.py
+++ b/examples/hints.py
@@ -118,7 +118,8 @@ def main():
         verbose = False
     filename = args.dir
     if verbose and rank == 0:
-        print("{}: example of file create and open".format(__file__))
+        print("{}: example of set/get PnetCDF hints".format(os.path.basename(__file__)))
+
     # create MPI info 
     info1 = MPI.Info.Create()
     info1.Set("nc_header_align_size", "1024")

--- a/examples/nonblocking_write.py
+++ b/examples/nonblocking_write.py
@@ -183,7 +183,7 @@ def main():
             length = int(args.l)
     filename = args.dir
     if verbose and rank == 0:
-        print("{}: example of file create and open".format(__file__))
+        print("{}: example of calling nonblocking write APIs".format(os.path.basename(__file__)))
 
     starts = np.zeros(NDIMS, dtype=np.int32)
     counts = np.zeros(NDIMS, dtype=np.int32)

--- a/examples/nonblocking_write_def.py
+++ b/examples/nonblocking_write_def.py
@@ -99,7 +99,8 @@ def main():
             length = int(args.l)
     filename = args.dir
     if verbose and rank == 0:
-        print("{}: example of file create and open".format(__file__))
+        print("{}: example of nonblocking APIs in define mode".format(os.path.basename(__file__)))
+
 
     starts = np.zeros(NDIMS, dtype=np.int32)
     counts = np.zeros(NDIMS, dtype=np.int32)

--- a/examples/put_vara.py
+++ b/examples/put_vara.py
@@ -153,7 +153,8 @@ def main():
         file_format = kind_dict[args.k]
     filename = args.dir
     if verbose and rank == 0:
-        print("{}: example of file create and open".format(__file__))
+        print("{}: example of writing subarrays".format(os.path.basename(__file__)))
+
     # Run pnetcdf i/o
     pnetcdf_io(comm, filename, file_format)
 

--- a/examples/put_varn_int.py
+++ b/examples/put_varn_int.py
@@ -99,7 +99,8 @@ def main():
         file_format = kind_dict[args.k]
     filename = args.dir
     if verbose and rank == 0:
-        print("{}: example of file create and open".format(__file__))
+        print("{}: example of writing multiple variables in a call".format(os.path.basename(__file__)))
+
     # Run pnetcdf i/o
     f = pnetcdf.File(filename=filename, mode = 'w', format=file_format, comm=comm, info=None)
     dimx = f.def_dim('x',NX)

--- a/examples/transpose.py
+++ b/examples/transpose.py
@@ -201,7 +201,8 @@ def main():
         length = int(args.l)
     filename = args.dir
     if verbose and rank == 0:
-        print("{}: example of file create and open".format(__file__))
+        print("{}: example of put/get 3D transposed arrays".format(os.path.basename(__file__)))
+
     # Run pnetcdf i/o
     pnetcdf_io(comm, filename, file_format, length)
 

--- a/examples/transpose2D.py
+++ b/examples/transpose2D.py
@@ -186,7 +186,7 @@ def main():
         length = int(args.l)
     filename = args.dir
     if verbose and rank == 0:
-        print("{}: example of file create and open".format(__file__))
+        print("{}: example of put/get 2D transposed arrays".format(os.path.basename(__file__)))
     # Run pnetcdf i/o
     pnetcdf_io(comm, filename, file_format, length)
 


### PR DESCRIPTION
There program descriptions are printed when running them individually with verbose mode turned on.