### PR TITLE
use makefiles to run tests

### DIFF
--- a/.github/workflows/pnetcdf_c_master.yml
+++ b/.github/workflows/pnetcdf_c_master.yml
@@ -92,17 +92,7 @@ jobs:
     - name: Test PnetCDF-Python
       run: |
         export PATH=${MPICH_DIR}/bin:${PATH}
-
-        chmod 700 ./test_all.sh
-        export NPROC=3 && ./test_all.sh
-        export NPROC=8 && ./test_all.sh
-        export NPROC=10 && ./test_all.sh
-
-        cd examples
-        chmod 700 ./test_all.sh
-        export NPROC=3 && ./test_all.sh
-        export NPROC=8 && ./test_all.sh
-        export NPROC=10 && ./test_all.sh
+        make ptests
 
 #   - name: Tarball
 #     run: |

--- a/.github/workflows/pnetcdf_c_official.yml
+++ b/.github/workflows/pnetcdf_c_official.yml
@@ -90,17 +90,7 @@ jobs:
     - name: Test PnetCDF-Python
       run: |
         export PATH=${MPICH_DIR}/bin:${PATH}
-
-        chmod 700 ./test_all.sh
-        export NPROC=3 && ./test_all.sh
-        export NPROC=8 && ./test_all.sh
-        export NPROC=10 && ./test_all.sh
-
-        cd examples
-        chmod 700 ./test_all.sh
-        export NPROC=3 && ./test_all.sh
-        export NPROC=8 && ./test_all.sh
-        export NPROC=10 && ./test_all.sh
+        make ptests
 
 #   - name: Tarball
 #     run: |

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+check:
+	cd test && make check
+	cd examples && make check
+
+ptests:
+	cd test && make ptests
+	cd examples && make ptests
+
+clean:
+	cd test && make clean
+	cd examples && make clean
+	
+build-clean:
+	rm -rf 	build/
+	rm -rf src/pnetcdf.egg-info/
+	rm -rf src/pnetcdf/_Dimension.c
+	rm -rf src/pnetcdf/_Dimension.*.so
+	rm -rf src/pnetcdf/_File.c
+	rm -rf src/pnetcdf/_File.*.so
+	rm -rf src/pnetcdf/_Variable.c
+	rm -rf src/pnetcdf/_Variable.*.so
+	rm -rf src/pnetcdf/_utils.c
+	rm -rf src/pnetcdf/_utils.*.so
+	rm -rf src/pnetcdf/__pycache__/
+	rm -rf test/__pycache__/
+

--- a/README.md
+++ b/README.md
@@ -29,26 +29,17 @@ applications that require parallel access to netCDF files.
   CC=/path/to/mpicc PNETCDF_DIR=/path/to/pnetcdf/dir pip install .
   ```
 * Testing
-  + Run command below to test all the test programs available in folder
-    `./test`, which will run 4 MPI processes for each test. The number of
-    processes can be changed by setting the environment variable `NPROC` to a
-    different number.
+  + Run command `make check` to test all the programs available in folders
+    `test` and `examples` in parallel on 4 MPI processes.
+  + In addition, command `make ptests` runs the same tests but using 3, 4, and
+    8 MPI processes.
+  + To run any individual programs in folders `test` and `examples`, use
+    command below. For example,
     ```sh
-    ./test_all.sh [test_file_output_dir]
+    mpiexec -n [num_process] python examples/create_open.py [output_dir]
     ```
-  + To run a specific individual test, run command below
-    ```sh
-    mpiexec -n [num_process] python test/tst_program.py [test_file_output_dir]
-    ```
-    * The optional `test_file_output_dir` argument enables the testing program
-      to save out generated test files in the directory. The default is the
-      current folder.
-  + Similarly, one can test all example programs in the folder `examples` by
-    running commands below.
-    ```sh
-    cd examples
-    ./test_all.sh [test_file_output_dir]
-    ```
+    * The optional `output_dir` argument is the folder for storing the output
+      files created by the programs The default is the current folder.
 
 ### Additional Resources
 * [PnetCDF-python User Guide](https://pnetcdf-python.readthedocs.io/en/latest/)

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,0 +1,55 @@
+
+check_PROGRAMS = collective_write.py \
+                 create_open.py \
+                 fill_mode.py \
+                 flexible_api.py \
+                 get_info.py \
+                 ghost_cell.py \
+                 global_attribute.py \
+                 hints.py \
+                 nonblocking_write_def.py \
+                 nonblocking_write.py \
+                 put_varn_int.py \
+                 transpose2D.py \
+                 transpose.py \
+                 put_vara.py \
+                 get_vara.py
+
+
+TESTS_ENVIRONMENT  = export check_PROGRAMS="${check_PROGRAMS}";
+TESTS_ENVIRONMENT += export PNETCDF_DIR="${PNETCDF_DIR}";
+
+OUTPUT_DIR = _tmp_output
+
+all:
+
+check: ptest4
+ptests: ptest3 ptest4 ptest8
+
+ptest3:
+	@mkdir -p ${OUTPUT_DIR}
+	@echo "==========================================================="
+	@echo "    examples: Parallel testing on 3 MPI processes"
+	@echo "==========================================================="
+	@${TESTS_ENVIRONMENT} export NPROC=3; ./parallel_run.sh ${OUTPUT_DIR} || exit 1
+	@echo ""
+
+ptest4:
+	@mkdir -p ${OUTPUT_DIR}
+	@echo "==========================================================="
+	@echo "    examples: Parallel testing on 4 MPI processes"
+	@echo "==========================================================="
+	@${TESTS_ENVIRONMENT} export NPROC=4; ./parallel_run.sh ${OUTPUT_DIR} || exit 1
+	@echo ""
+
+ptest8:
+	@mkdir -p ${OUTPUT_DIR}
+	@echo "==========================================================="
+	@echo "    examples: Parallel testing on 8 MPI processes"
+	@echo "==========================================================="
+	@${TESTS_ENVIRONMENT} export NPROC=8; ./parallel_run.sh ${OUTPUT_DIR} || exit 1
+	@echo ""
+
+clean:
+	rm -rf ${OUTPUT_DIR}
+

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,0 +1,81 @@
+
+check_PROGRAMS = tst_atts.py \
+                 tst_default_format.py \
+                 tst_dims.py \
+                 tst_file_fill.py \
+                 tst_file_inq.py \
+                 tst_file_mode.py \
+                 tst_rename.py \
+                 tst_var_bput_var1.py \
+                 tst_var_bput_vara.py \
+                 tst_var_bput_varm.py \
+                 tst_var_bput_varn.py \
+                 tst_var_bput_var.py \
+                 tst_var_bput_vars.py \
+                 tst_var_def_fill.py \
+                 tst_var_get_var1.py \
+                 tst_var_get_vara.py \
+                 tst_var_get_varm.py \
+                 tst_var_get_varn.py \
+                 tst_var_get_var.py \
+                 tst_var_get_vars.py \
+                 tst_var_iget_var1.py \
+                 tst_var_iget_vara.py \
+                 tst_var_iget_varm.py \
+                 tst_var_iget_varn.py \
+                 tst_var_iget_var.py \
+                 tst_var_iget_vars.py \
+                 tst_var_indexer.py \
+                 tst_var_iput_var1.py \
+                 tst_var_iput_vara.py \
+                 tst_var_iput_varm.py \
+                 tst_var_iput_varn.py \
+                 tst_var_iput_var.py \
+                 tst_var_iput_vars.py \
+                 tst_var_put_var1.py \
+                 tst_var_put_vara.py \
+                 tst_var_put_varm.py \
+                 tst_var_put_varn.py \
+                 tst_var_put_var.py \
+                 tst_var_put_vars.py \
+                 tst_var_rec_fill.py \
+                 tst_var_string.py \
+                 tst_var_type.py \
+                 tst_version.py \
+                 tst_wait.py
+
+TESTS_ENVIRONMENT = export check_PROGRAMS="${check_PROGRAMS}";
+OUTPUT_DIR = _tmp_output
+
+all:
+
+check: ptest4
+ptests: ptest3 ptest4 ptest8
+
+ptest3:
+	@mkdir -p ${OUTPUT_DIR}
+	@echo "==========================================================="
+	@echo "    test: Parallel testing on 3 MPI processes"
+	@echo "==========================================================="
+	@${TESTS_ENVIRONMENT} export NPROC=3; ./parallel_run.sh ${OUTPUT_DIR} || exit 1
+	@echo ""
+
+ptest4:
+	@mkdir -p ${OUTPUT_DIR}
+	@echo "==========================================================="
+	@echo "    test: Parallel testing on 4 MPI processes"
+	@echo "==========================================================="
+	@${TESTS_ENVIRONMENT} export NPROC=4; ./parallel_run.sh ${OUTPUT_DIR} || exit 1
+	@echo ""
+
+ptest8:
+	@mkdir -p ${OUTPUT_DIR}
+	@echo "==========================================================="
+	@echo "    test: Parallel testing on 8 MPI processes"
+	@echo "==========================================================="
+	@${TESTS_ENVIRONMENT} export NPROC=8; ./parallel_run.sh ${OUTPUT_DIR} || exit 1
+	@echo ""
+
+clean:
+	rm -rf ${OUTPUT_DIR}
+

--- a/test/parallel_run.sh
+++ b/test/parallel_run.sh
@@ -25,19 +25,18 @@ else
    # output folder is not set at command line, use current folder
    OUT_DIR="."
 fi
-echo "OUT_DIR=$OUT_DIR"
+# echo "OUT_DIR=$OUT_DIR"
 
-TETS_PROGS=`ls test/tst_*.py`
-for prog in $TETS_PROGS
-do
-  echo -n "---- Testing $prog with $NPROC MPI processes"
-  CMD="mpiexec -n $NPROC python $prog $OUT_DIR"
-  $CMD
-  status=$?
+for prog in ${check_PROGRAMS} ; do
+   printf '%-60s' "Testing $prog "
+
+   CMD="mpiexec -n $NPROC python $prog $OUT_DIR"
+   $CMD
+   status=$?
    if [ $status -ne 0 ]; then
-      echo ": FAIL ----"
+      echo " ---- FAIL"
    else
-      echo ": PASS ----"
+      echo " ---- PASS"
    fi
 done
 


### PR DESCRIPTION
* `"make check"` runs programs in both folders `test` and `examples` on 4 MPI processes.
* `"make ptests"` runs the same, but on 3, 4, and 8 MPI processes.
* `"make clean"` deletes the temporarily created output folders in `test` and `examples`.
* `"make build-clean"` deletes files created during `"pip install"` time.