### PR TITLE
Fix build warnings: data type redeclared

### DIFF
--- a/src/pnetcdf/_Dimension.pyx
+++ b/src/pnetcdf/_Dimension.pyx
@@ -9,12 +9,8 @@ from ._File cimport File
 from ._utils cimport _strencode, _check_err
 cimport mpi4py.MPI as MPI
 
-ctypedef MPI.Offset Offset
-
-
 from libc.string cimport memcpy, memset
 from libc.stdlib cimport malloc, free
-from mpi4py.libmpi cimport MPI_Offset
 
 include "PnetCDF.pxi"
 

--- a/src/pnetcdf/_utils.pyx
+++ b/src/pnetcdf/_utils.pyx
@@ -5,13 +5,11 @@
 #
 ###############################################################################
 
-include "PnetCDF.pxi"
 from ._File cimport File
 from cpython.mem cimport PyMem_Malloc, PyMem_Free
 import numpy as np
 from numpy.lib.stride_tricks import as_strided
 from libc.stdlib cimport malloc, free
-from mpi4py.libmpi cimport MPI_Offset
 from mpi4py import MPI
 
 


### PR DESCRIPTION
```
[1/1] Cythonizing src/pnetcdf/_Dimension.pyx
warning: include/PnetCDF.pxi:19:4: 'MPI_Offset' redeclared 
building 'pnetcdf._Dimension' extension
...
[1/1] Cythonizing src/pnetcdf/_utils.pyx
warning: include/PnetCDF.pxi:12:4: 'const_char_ptr' redeclared 
warning: include/PnetCDF.pxi:17:4: 'MPI_Comm' redeclared 
warning: include/PnetCDF.pxi:18:4: 'MPI_Info' redeclared 
...
```