### PR TITLE
simplify examples

### DIFF
--- a/examples/collective_write.py
+++ b/examples/collective_write.py
@@ -31,16 +31,12 @@ netCDF file produced by this example program:
         32     400 x  400 x  200     6.67       45.72
 """
 
-import sys, os, argparse, inspect
+import sys, os, argparse
 import numpy as np
 from mpi4py import MPI
 import pnetcdf
 
-NDIMS = 3
-NUM_VARS = 10
-
-def parse_help(comm):
-    rank = comm.Get_rank()
+def parse_help():
     help_flag = "-h" in sys.argv or "--help" in sys.argv
     if help_flag and rank == 0:
         help_text = (
@@ -54,21 +50,22 @@ def parse_help(comm):
         print(help_text)
     return help_flag
 
-def print_info(info_used):
-    print("MPI hint: cb_nodes        =", info_used.Get("cb_nodes"))
-    print("MPI hint: cb_buffer_size  =", info_used.Get("cb_buffer_size"))
-    print("MPI hint: striping_factor =", info_used.Get("striping_factor"))
-    print("MPI hint: striping_unit   =", info_used.Get("striping_unit"))
+def pnetcdf_io(filename, file_format, length):
+    # number of dimensions
+    NDIMS = 3
+    # number of variables
+    NUM_VARS = 10
 
-def pnetcdf_io(comm, filename, file_format, length):
-    rank = comm.Get_rank()
-    nprocs = comm.Get_size()
+    if verbose and rank == 0:
+        print("Number of variables = ", NUM_VARS)
+        print("Number of dimensions = ", NDIMS)
 
     starts = np.zeros(NDIMS, dtype=np.int32)
     counts = np.zeros(NDIMS, dtype=np.int32)
     gsizes = np.zeros(NDIMS, dtype=np.int32)
     buf = []
 
+    # calculate local subarray access pattern
     psizes = MPI.Compute_dims(nprocs, NDIMS)
     starts[0] = rank % psizes[0]
     starts[1] = (rank // psizes[1]) % psizes[1]
@@ -87,20 +84,12 @@ def pnetcdf_io(comm, filename, file_format, length):
         for j in range(bufsize):
             buf[i][j] = rank * i + 123 + j
 
-    comm.Barrier()
-    write_timing = MPI.Wtime()
-
     # Create the file using file clobber mode
-    try:
-        f = pnetcdf.File(filename = filename,  \
-                         mode = 'w',           \
-                         format = file_format, \
-                         comm = comm,          \
-                         info = None)
-    except OSError as e:
-        print("Error at {}:{} ncmpi_create() file {} ({})".format(__file__,inspect.currentframe().f_back.f_lineno, filename, e))
-        comm.Abort()
-        exit(1)
+    f = pnetcdf.File(filename = filename,
+                     mode = 'w',
+                     format = file_format,
+                     comm = comm,
+                     info = None)
 
     # Define dimensions
     dims = []
@@ -127,34 +116,14 @@ def pnetcdf_io(comm, filename, file_format, length):
     # Close the file
     f.close()
 
-    write_timing = MPI.Wtime() - write_timing
-
-    # calculate write amount across all processes in total
-    write_size = bufsize * NUM_VARS * np.dtype(np.int32).itemsize
-    sum_write_size = comm.reduce(write_size, MPI.SUM, root=0)
-    max_write_timing = comm.reduce(write_timing, MPI.MAX, root=0)
-
-    if rank == 0 and verbose:
-        subarray_size = (bufsize * np.dtype(np.int32).itemsize) / 1048576.0
-        print_info(info_used)
-        print("Local array size {} x {} x {} integers, size = {:.2f} MB".format(length, length, length, subarray_size))
-        sum_write_size /= 1048576.0
-        print("Global array size {} x {} x {} integers, write size = {:.2f} GB".format(gsizes[0], gsizes[1], gsizes[2], sum_write_size/1024.0))
-
-        write_bw = sum_write_size / max_write_timing
-        print(" procs    Global array size  exec(sec)  write(MB/s)")
-        print("-------  ------------------  ---------  -----------")
-        print(" {:4d}    {:4d} x {:4d} x {:4d} {:8.2f}  {:10.2f}\n".format(nprocs, gsizes[0], gsizes[1], gsizes[2], max_write_timing, write_bw))
-
 
 if __name__ == "__main__":
 
-    verbose = True
     comm = MPI.COMM_WORLD
     rank = comm.Get_rank()
     nprocs = comm.Get_size()
 
-    if parse_help(comm):
+    if parse_help():
         MPI.Finalize()
         sys.exit(1)
 
@@ -168,25 +137,25 @@ if __name__ == "__main__":
     parser.add_argument("-l", help="Size of each dimension of the local array\n")
     args = parser.parse_args()
 
+    verbose = False if args.q else True
+
     file_format = None
-    length = 10
-
-    if args.q: verbose = False
-
     if args.k:
-        kind_dict = {'1':None, '2':"NETCDF3_64BIT_OFFSET", '5':"NETCDF3_64BIT_DATA"}
+        kind_dict = {'1':None, '2':"NC_64BIT_OFFSET", '5':"NC_64BIT_DATA"}
         file_format = kind_dict[args.k]
 
+    length = 10
     if args.l and int(args.l) > 0:
         length = int(args.l)
 
     filename = args.dir
+
     if verbose and rank == 0:
         print("{}: example of collective writes".format(os.path.basename(__file__)))
 
     # Run I/O
     try:
-        pnetcdf_io(comm, filename, file_format, length)
+        pnetcdf_io(filename, file_format, length)
     except BaseException as err:
         print("Error: type:", type(err), str(err))
         raise

--- a/examples/create_open.py
+++ b/examples/create_open.py
@@ -34,11 +34,12 @@ def parse_help():
     return help_flag
 
 def pnetcdf_io(filename):
-    if verbose and rank == 0:
-        print("{}: example of file create and open".format(os.path.basename(__file__)))
 
     # create a new file using file clobber mode, i.e. flag "-w"
-    f = pnetcdf.File(filename=filename, mode = 'w', comm=comm, info=None)
+    f = pnetcdf.File(filename = filename,
+                     mode = 'w',
+                     comm = comm,
+                     info = None)
 
     # close the file
     f.close()
@@ -51,7 +52,6 @@ def pnetcdf_io(filename):
 
 
 if __name__ == "__main__":
-    verbose = True
     comm = MPI.COMM_WORLD
     rank = comm.Get_rank()
     nprocs = comm.Get_size()
@@ -68,9 +68,12 @@ if __name__ == "__main__":
     parser.add_argument("-q", help="Quiet mode (reports when fail)", action="store_true")
     args = parser.parse_args()
 
-    if args.q: verbose = False
+    verbose = False if args.q else True
 
     filename = args.dir
+
+    if verbose and rank == 0:
+        print("{}: example of file create and open".format(os.path.basename(__file__)))
 
     try:
         pnetcdf_io(filename)

--- a/examples/fill_mode.py
+++ b/examples/fill_mode.py
@@ -63,10 +63,14 @@ def pnetcdf_io(filename):
     NX = 4
 
     if verbose and rank == 0:
-        print("{}: example of setting fill mode".format(os.path.basename(__file__)))
+        print("Y dimension size = ", NY)
+        print("X dimension size = ", NX)
 
     # create a new file using clobber "w" mode
-    f = pnetcdf.File(filename=filename, mode = 'w', comm=comm, info=None)
+    f = pnetcdf.File(filename = filename,
+                     mode = 'w',
+                     comm = comm,
+                     info = None)
 
     # the global array is NY * (NX * nprocs)
     global_ny = NY
@@ -131,7 +135,10 @@ def pnetcdf_io(filename):
 
     # write to the 2nd record
     rec_var.put_var_all(buf, start = starts, count = counts)
+
+    # close file
     f.close()
+
 
 if __name__ == "__main__":
     verbose = True
@@ -152,9 +159,13 @@ if __name__ == "__main__":
     parser.add_argument("-q", help="Quiet mode (reports when fail)", action="store_true")
 
     args = parser.parse_args()
-    if args.q: verbose = False
+
+    verbose = False if args.q else True
 
     filename = args.dir
+
+    if verbose and rank == 0:
+        print("{}: example of setting fill mode".format(os.path.basename(__file__)))
 
     try:
         pnetcdf_io(filename)

--- a/examples/get_info.py
+++ b/examples/get_info.py
@@ -50,6 +50,7 @@ def parse_help():
         print(help_text)
     return help_flag
 
+
 def print_info(info_used):
     nkeys = info_used.Get_nkeys()
     print("MPI File Info: nkeys =", nkeys)
@@ -60,11 +61,13 @@ def print_info(info_used):
 
 
 def pnetcdf_io(filename):
-    if verbose and rank == 0:
-        print("{}: example of getting MPI-IO hints".format(os.path.basename(__file__)))
 
     # create a new file using clobber "w" mode
-    f = pnetcdf.File(filename=filename, mode = 'w', file_format = "NETCDF3_64BIT_DATA", comm=comm, info=None)
+    f = pnetcdf.File(filename=filename,
+                     mode = 'w',
+                     file_format = "NC_64BIT_DATA",
+                     comm=comm,
+                     info=None)
 
     # exit the define mode
     f.enddef()
@@ -82,7 +85,6 @@ def pnetcdf_io(filename):
 
 
 if __name__ == "__main__":
-    verbose = True
     comm = MPI.COMM_WORLD
     rank = comm.Get_rank()
     nprocs = comm.Get_size()
@@ -99,9 +101,12 @@ if __name__ == "__main__":
     parser.add_argument("-q", help="Quiet mode (reports when fail)", action="store_true")
     args = parser.parse_args()
 
-    if args.q: verbose = False
+    verbose = False if args.q else True
 
     filename = args.dir
+
+    if verbose and rank == 0:
+        print("{}: example of getting MPI-IO hints".format(os.path.basename(__file__)))
 
     try:
         pnetcdf_io(filename)

--- a/examples/global_attribute.py
+++ b/examples/global_attribute.py
@@ -48,13 +48,14 @@ def parse_help():
 def pnetcdf_io(filename, file_format):
     digit = np.int16([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
 
-    if verbose and rank == 0:
-        print("{}: example of put/get global attributes".format(os.path.basename(__file__)))
-
     # Run pnetcdf i/o
 
     # Create the file
-    f = pnetcdf.File(filename=filename, mode = 'w', format = file_format, comm=comm, info=None)
+    f = pnetcdf.File(filename = filename,
+                     mode = 'w',
+                     format = file_format,
+                     comm = comm,
+                     info = None)
 
     if rank == 0:
         ltime = time.localtime()
@@ -107,7 +108,6 @@ def pnetcdf_io(filename, file_format):
 
 
 if __name__ == "__main__":
-    verbose = True
     comm = MPI.COMM_WORLD
     rank = comm.Get_rank()
     nprocs = comm.Get_size()
@@ -125,14 +125,17 @@ if __name__ == "__main__":
     parser.add_argument("-k", help="File format: 1 for CDF-1, 2 for CDF-2, 5 for CDF-5")
     args = parser.parse_args()
 
-    if args.q: verbose = False
-
-    filename = args.dir
+    verbose = False if args.q else True
 
     file_format = None
     if args.k:
-        kind_dict = {'1':None, '2':"NETCDF3_64BIT_OFFSET", '5':"NETCDF3_64BIT_DATA"}
+        kind_dict = {'1':None, '2':"NC_64BIT_OFFSET", '5':"NC_64BIT_DATA"}
         file_format = kind_dict[args.k]
+
+    filename = args.dir
+
+    if verbose and rank == 0:
+        print("{}: example of put/get global attributes".format(os.path.basename(__file__)))
 
     try:
         pnetcdf_io(filename, file_format)

--- a/examples/hints.py
+++ b/examples/hints.py
@@ -94,16 +94,22 @@ def pnetcdf_io(filename):
     NZ = 5
 
     if verbose and rank == 0:
-        print("{}: example of set/get PnetCDF hints".format(os.path.basename(__file__)))
+        print("Z dimension size = ", NZ)
+        print("Y dimension size = ", NY)
+        print("X dimension size = ", NX)
 
     # create MPI info object and set a few hints
-    info1 = MPI.Info.Create()
-    info1.Set("nc_header_align_size", "1024")
-    info1.Set("nc_var_align_size", "512")
-    info1.Set("nc_header_read_chunk_size", "256")
+    info = MPI.Info.Create()
+    info.Set("nc_header_align_size", "1024")
+    info.Set("nc_var_align_size", "512")
+    info.Set("nc_header_read_chunk_size", "256")
 
     # create a new file for writing
-    f = pnetcdf.File(filename=filename, mode = 'w', file_format = "NETCDF3_64BIT_DATA", comm=comm, info=info1)
+    f = pnetcdf.File(filename = filename,
+                     mode = 'w',
+                     format = "NC_64BIT_DATA",
+                     comm = comm,
+                     info = info)
 
     # define dimensions
     dim_z = f.def_dim('Z', NZ*nprocs)
@@ -144,14 +150,13 @@ def pnetcdf_io(filename):
 
     if verbose and rank == 0:
         print_hints(f, var_zy, var_yx)
-    info1.Free()
+    info.Free()
 
     # close the file
     f.close()
 
 
 if __name__ == "__main__":
-    verbose = True
     comm = MPI.COMM_WORLD
     rank = comm.Get_rank()
     nprocs = comm.Get_size()
@@ -168,9 +173,12 @@ if __name__ == "__main__":
     parser.add_argument("-q", help="Quiet mode (reports when fail)", action="store_true")
     args = parser.parse_args()
 
-    if args.q: verbose = False
+    verbose = False if args.q else True
 
     filename = args.dir
+
+    if verbose and rank == 0:
+        print("{}: example of set/get PnetCDF hints".format(os.path.basename(__file__)))
 
     try:
         pnetcdf_io(filename)

--- a/examples/nonblocking_write.py
+++ b/examples/nonblocking_write.py
@@ -49,18 +49,14 @@ def parse_help():
         print(help_text)
     return help_flag
 
-def print_info(info_used):
-    print("MPI hint: cb_nodes        =", info_used.Get("cb_nodes"))
-    print("MPI hint: cb_buffer_size  =", info_used.Get("cb_buffer_size"))
-    print("MPI hint: striping_factor =", info_used.Get("striping_factor"))
-    print("MPI hint: striping_unit   =", info_used.Get("striping_unit"))
 
 def pnetcdf_io(filename, length):
     NDIMS = 3
     NUM_VARS = 10
 
     if verbose and rank == 0:
-        print("{}: example of calling nonblocking write APIs".format(os.path.basename(__file__)))
+        print("Number of variables = ", NUM_VARS)
+        print("Number of dimensions = ", NDIMS)
 
     # set up subarray access pattern
     starts = np.zeros(NDIMS, dtype=np.int32)
@@ -86,16 +82,12 @@ def pnetcdf_io(filename, length):
         for j in range(bufsize):
             buf[i][j] = rank * i + 123 + j
 
-    comm.Barrier()
-    write_timing = MPI.Wtime()
-
     # Create the file
-    try:
-        f = pnetcdf.File(filename=filename, mode = 'w', format = "NETCDF3_64BIT_DATA", comm=comm, info=None)
-    except OSError as e:
-        print("Error at {}:{} ncmpi_create() file {} ({})".format(__file__,inspect.currentframe().f_back.f_lineno, filename, e))
-        comm.Abort()
-        sys.exit(1)
+    f = pnetcdf.File(filename = filename,
+                     mode = 'w',
+                     format = "NC_64BIT_DATA",
+                     comm = comm,
+                     info = None)
 
     # Define dimensions
     dims = []
@@ -111,9 +103,6 @@ def pnetcdf_io(filename, length):
 
     # Exit the define mode
     f.enddef()
-
-    # Get all the hints used
-    info_used = f.inq_info()
 
     # Write one variable at a time, using iput APIs
     reqs = []
@@ -153,38 +142,11 @@ def pnetcdf_io(filename, length):
     # detach the temporary buffer
     f.detach_buff()
 
-    # obtain write amount yet to now
-    put_size = f.inq_put_size()
-    put_size = comm.allreduce(put_size, op=MPI.SUM)
-
     # Close the file
     f.close()
 
-    write_timing = MPI.Wtime() - write_timing
-
-    write_size = bufsize * NUM_VARS * np.dtype(np.int32).itemsize
-    sum_write_size = comm.reduce(write_size, MPI.SUM, root=0)
-    max_write_timing = comm.reduce(write_timing, MPI.MAX, root=0)
-
-    if rank == 0 and verbose:
-        print()
-        print("Total amount writes to variables only   (exclude header) = {} bytes".format(sum_write_size))
-        print("Total amount writes reported by pnetcdf (include header) = {} bytes".format(put_size))
-        print()
-        subarray_size = (bufsize * np.dtype(np.int32).itemsize) / 1048576.0
-        print_info(info_used)
-        print("Local array size {} x {} x {} integers, size = {:.2f} MB".format(length, length, length, subarray_size))
-        sum_write_size /= 1048576.0
-        print("Global array size {} x {} x {} integers, write size = {:.2f} GB".format(gsizes[0], gsizes[1], gsizes[2], sum_write_size/1024.0))
-
-        write_bw = sum_write_size / max_write_timing
-        print(" procs    Global array size  exec(sec)  write(MB/s)")
-        print("-------  ------------------  ---------  -----------")
-        print(" {:4d}    {:4d} x {:4d} x {:4d} {:8.2f}  {:10.2f}\n".format(nprocs, gsizes[0], gsizes[1], gsizes[2], max_write_timing, write_bw))
-
 
 if __name__ == "__main__":
-    verbose = True
     comm = MPI.COMM_WORLD
     rank = comm.Get_rank()
     nprocs = comm.Get_size()
@@ -202,12 +164,15 @@ if __name__ == "__main__":
     parser.add_argument("-l", help="Size of each dimension of the local array\n")
     args = parser.parse_args()
 
-    if args.q: verbose = False
+    verbose = False if args.q else True
 
     length = 10
     if args.l and int(args.l) > 0: length = int(args.l)
 
     filename = args.dir
+
+    if verbose and rank == 0:
+        print("{}: example of calling nonblocking write APIs".format(os.path.basename(__file__)))
 
     try:
         pnetcdf_io(filename, length)

--- a/examples/put_vara.py
+++ b/examples/put_vara.py
@@ -71,9 +71,6 @@ def parse_help():
 
 
 def pnetcdf_io(filename, file_format):
-    if verbose and rank == 0:
-        print("{}: example of writing subarrays".format(os.path.basename(__file__)))
-
     NY = 10
     NX = 4
     global_ny = NY
@@ -81,8 +78,16 @@ def pnetcdf_io(filename, file_format):
     starts = [0, NX * rank]
     counts = [NY, NX]
 
+    if verbose and rank == 0:
+        print("Y dimension size = ", NY)
+        print("X dimension size = ", NX)
+
     # Create the file
-    f = pnetcdf.File(filename=filename, mode = 'w', format = file_format, comm=comm, info=None)
+    f = pnetcdf.File(filename = filename,
+                     mode = 'w',
+                     format = file_format,
+                     comm = comm,
+                     info = None)
 
     # Add a global attribute: a time stamp at rank 0
     if rank == 0:
@@ -113,7 +118,7 @@ def pnetcdf_io(filename, file_format):
     short_att = np.int16(1000)
     var.put_att("short_att_name", short_att)
 
-     # Exit the define mode
+    # Exit the define mode
     f.enddef()
 
     # initialize write buffer
@@ -127,7 +132,6 @@ def pnetcdf_io(filename, file_format):
 
 
 if __name__ == "__main__":
-    verbose = True
     comm = MPI.COMM_WORLD
     rank = comm.Get_rank()
     nprocs = comm.Get_size()
@@ -145,14 +149,17 @@ if __name__ == "__main__":
     parser.add_argument("-k", help="File format: 1 for CDF-1, 2 for CDF-2, 5 for CDF-5")
     args = parser.parse_args()
 
-    if args.q: verbose = False
+    verbose = False if args.q else True
 
     file_format = None
     if args.k:
-        kind_dict = {'1':None, '2':"NETCDF3_64BIT_OFFSET", '5':"NETCDF3_64BIT_DATA"}
+        kind_dict = {'1':None, '2':"NC_64BIT_OFFSET", '5':"NC_64BIT_DATA"}
         file_format = kind_dict[args.k]
 
     filename = args.dir
+
+    if verbose and rank == 0:
+        print("{}: example of writing subarrays".format(os.path.basename(__file__)))
 
     try:
         pnetcdf_io(filename, file_format)

--- a/examples/transpose2D.py
+++ b/examples/transpose2D.py
@@ -66,10 +66,10 @@ def parse_help():
     return help_flag
 
 def pnetcdf_io(filename, file_format, length):
-    if verbose and rank == 0:
-        print("{}: example of put/get 2D transposed arrays".format(os.path.basename(__file__)))
-
     NDIMS = 2
+
+    if verbose and rank == 0:
+        print("Number of dimensions = ", NDIMS)
 
     gsizes = np.zeros(NDIMS, dtype=np.int64)
     starts = np.zeros(NDIMS, dtype=np.int64)
@@ -114,7 +114,11 @@ def pnetcdf_io(filename, file_format, length):
 
 
     # Create the file
-    f = pnetcdf.File(filename=filename, mode = 'w', format = file_format, comm=comm, info=None)
+    f = pnetcdf.File(filename = filename,
+                     mode = 'w',
+                     format = file_format,
+                     comm = comm,
+                     info = None)
 
     # Define dimensions
     dim_y = f.def_dim("Y", gsizes[0])
@@ -144,7 +148,6 @@ def pnetcdf_io(filename, file_format, length):
 
 
 if __name__ == "__main__":
-    verbose = True
     comm = MPI.COMM_WORLD
     rank = comm.Get_rank()
     nprocs = comm.Get_size()
@@ -163,17 +166,20 @@ if __name__ == "__main__":
     parser.add_argument("-l", help="size of each dimension of the local array")
     args = parser.parse_args()
 
-    if args.q: verbose = False
+    verbose = False if args.q else True
 
     file_format = None
     if args.k:
-        kind_dict = {'1':None, '2':"NETCDF3_64BIT_OFFSET", '5':"NETCDF3_64BIT_DATA"}
+        kind_dict = {'1':None, '2':"NC_64BIT_OFFSET", '5':"NC_64BIT_DATA"}
         file_format = kind_dict[args.k]
 
     length = 2
     if args.l and int(args.l) > 0: length = int(args.l)
 
     filename = args.dir
+
+    if verbose and rank == 0:
+        print("{}: example of put/get 2D transposed arrays".format(os.path.basename(__file__)))
 
     try:
         pnetcdf_io(filename, file_format, length)


### PR DESCRIPTION
Keep only the essential components, i.e. API usages.
Remove print_info
Remove timing report
