### PR TITLE
Set minimal requirement of setuptools version >= 64.0.0

### DIFF
--- a/.github/workflows/pnetcdf_c_master.yml
+++ b/.github/workflows/pnetcdf_c_master.yml
@@ -79,8 +79,8 @@ jobs:
 
     - name: Install python dependencies via pip
       run: |
-        python -m pip install --upgrade pip
-        pip install numpy cython cftime pytest twine wheel check-manifest
+        python -m pip install --upgrade pip setuptools wheel
+        pip install numpy cython cftime pytest twine check-manifest
         export MPICC=$MPICH_DIR/bin/mpicc
         pip install mpi4py
         pip install torch torchvision

--- a/.github/workflows/pnetcdf_c_official.yml
+++ b/.github/workflows/pnetcdf_c_official.yml
@@ -77,8 +77,8 @@ jobs:
 
     - name: Install python dependencies via pip
       run: |
-        python -m pip install --upgrade pip
-        pip install numpy cython cftime pytest twine wheel check-manifest
+        python -m pip install --upgrade pip setuptools wheel
+        pip install numpy cython cftime pytest twine check-manifest
         export MPICC=$MPICH_DIR/bin/mpicc
         pip install mpi4py
         pip install torch torchvision

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ applications that require parallel access to netCDF files.
 ### Developer Installation
 * Clone this GitHub repository
 * Make sure the above dependent software are installed.
-* In addition, [Cython](http://cython.org/), [packaging](https://pypi.org/project/packaging/) and ['wheel'](https://pypi.org/project/wheel/) are required for developer installation.
+* In addition, [Cython](http://cython.org/), [packaging](https://pypi.org/project/packaging/), [setuptools>=65](https://pypi.org/project/setuptools/) and [wheel](https://pypi.org/project/wheel/) are required for developer installation.
 * Set the environment variable `PNETCDF_DIR` to PnetCDF's installation path.
 * Make sure utility program `pnetcdf-config` is available in `$PNETCDF_DIR/bin`.
 * Run command below to install.

--- a/docs/source/installation/install.rst
+++ b/docs/source/installation/install.rst
@@ -46,10 +46,10 @@ Building PnetCDF-python from source
      # use Python 3.9 or later
      $ python -m venv env
      $ source env/bin/activate
-     $ pip install --upgrade pip
+     $ pip install --upgrade pip setuptools wheel packaging
 
      # install Python libraries
-     $ pip install numpy Cython setuptools wheel packaging
+     $ pip install numpy Cython
      $ env CC=/path/to/mpicc pip install mpi4py
 
      # download PnetCDF-python source code


### PR DESCRIPTION
An installation issue occurs when installing using setuptools<64.0.0 version. When a python virtual env is created, it can have setuptools==58 installed by default, which is not compatible with pip install -e. The following msg appears at installation and the installation is not successful.
`DEPRECATION: Legacy editable install of pnetcdf==0.1.0 (setup.py develop) is deprecated. pip 25.0 will enforce this behaviour change. A possible replacement is to add a pyproject.toml or enable --use-pep517, and use setuptools >= 64. If the resulting installation is not behaving as expected, try using --config-settings editable_mode=compat. Please consult the setuptools documentation for more information. Discussion can be found at https://github.com/pypa/pip/issues/11457`

To fix this, just force upgrading python packaging libraries when installing dependencies. Alternative fix is to turn off editable mode.

