### PR TITLE
Remove argument index fro var1 APIs

### DIFF
--- a/test/tst_file_fill.py
+++ b/test/tst_file_fill.py
@@ -56,8 +56,8 @@ class FileTestCase(unittest.TestCase):
         f.enddef()
         v1 = f.variables['data1']
         v2 = f.variables['data2']
-        v1.put_var_all(np.int32(rank), index = (rank, rank))
-        v2.put_var_all(np.int32(rank), index = (rank, rank))
+        v1.put_var_all(np.int32(rank), start = (rank, rank))
+        v2.put_var_all(np.int32(rank), start = (rank, rank))
         f.close()
         assert validate_nc_file(os.environ.get('PNETCDF_DIR'), self.file_path) == 0 if os.environ.get('PNETCDF_DIR') is not None else True
 

--- a/test/tst_var_bput_var1.py
+++ b/test/tst_var_bput_var1.py
@@ -62,7 +62,7 @@ class VariablesTestCase(unittest.TestCase):
             v[:,::-1,:] = data
         # each process post 10 requests to write a single element
         req_ids = []
-        index = (rank, rank, rank)
+        start = (rank, rank, rank)
         value = np.int32(rank * 10 + 1)
         # estimate the memory buffer size of all requests and attach buffer for buffered put requests
         buffsize = num_reqs * 4
@@ -72,7 +72,7 @@ class VariablesTestCase(unittest.TestCase):
         for i in range(num_reqs):
             v = f.variables[f'data{i}']
             # post the request to write a single element
-            req_id = v.bput_var(value, index = index)
+            req_id = v.bput_var(value, start)
             # track the reqeust ID for each write reqeust
             req_ids.append(req_id)
 
@@ -89,7 +89,7 @@ class VariablesTestCase(unittest.TestCase):
         for i in range(num_reqs, num_reqs * 2):
             v = f.variables[f'data{i}']
             # post the request to write a single element
-            v.bput_var(value, index = index)
+            v.bput_var(value, start)
 
         # all processes commit all pending requests to the file at once using wait_all (collective i/o)
         f.wait_all(num = pnetcdf.NC_PUT_REQ_ALL)

--- a/test/tst_var_def_fill.py
+++ b/test/tst_var_def_fill.py
@@ -72,7 +72,7 @@ class VariablesTestCase(unittest.TestCase):
         # enter data mode and write partially values to variables
         f.enddef()
         for v in [v1,v2,v3,v4]:
-            v.put_var_all(np.float32(rank + 1), index = (rank, rank))
+            v.put_var_all(np.float32(rank + 1), (rank, rank))
         self.v1_nofill, self.v1_fillvalue = v1.inq_fill()
         self.v2_nofill, self.v2_fillvalue = v2.inq_fill()
         self.v3_nofill, self.v3_fillvalue = v3.inq_fill()

--- a/test/tst_var_get_var1.py
+++ b/test/tst_var_get_var1.py
@@ -61,18 +61,18 @@ class VariablesTestCase(unittest.TestCase):
         v1 = f.variables['data1u']
         # test collective i/o put var1
          # equivalent code to the following using indexer syntax: value = v1[rank][rank][rank]
-        index = (rank, rank, rank)
+        start = (rank, rank, rank)
         f.begin_indep()
         # all processes read the designated cell of the variable using independent i/o
         buff = np.empty((), v1.dtype)
-        v1.get_var(buff, index = index)
+        v1.get_var(buff, start)
         # compare returned value against reference value
         assert_equal(buff, datarev[rank][rank][rank])
         # test independent i/o put var1
         f.end_indep()
         # all processes read the designated cell of the variable using collective i/o
         buff = np.empty((), v1.dtype)
-        v1.get_var_all(buff, index = index)
+        v1.get_var_all(buff, start)
         # compare returned value against reference value
         assert_equal(buff, datarev[rank][rank][rank])
         f.close()

--- a/test/tst_var_get_varm.py
+++ b/test/tst_var_get_varm.py
@@ -78,13 +78,13 @@ class VariablesTestCase(unittest.TestCase):
         f.end_indep()
         v1 = f.variables['data1']
         v1_data = np.empty((2,3), dtype = np.float32)
-        v1.get_var_all(buff = v1_data, start = starts, count = counts, stride = strides, imap = imap)
+        v1.get_var_all(data = v1_data, start = starts, count = counts, stride = strides, imap = imap)
         assert_array_equal(v1_data, dataref)
 
          # Test reading from the variable in independent mode
         f.begin_indep()
         v1_data = np.empty((2,3), dtype = np.float32)
-        v1.get_var(buff = v1_data, start = starts, count = counts, stride = strides, imap = imap)
+        v1.get_var(data = v1_data, start = starts, count = counts, stride = strides, imap = imap)
         assert_array_equal(v1_data, dataref)
         f.close()
 

--- a/test/tst_var_iget_var1.py
+++ b/test/tst_var_iget_var1.py
@@ -70,12 +70,12 @@ class VariablesTestCase(unittest.TestCase):
         # each process post 10 requests to read a single element
         req_ids = []
         v_datas.clear()
-        index = (rank, rank, rank)
+        start = (rank, rank, rank)
         for i in range(num_reqs):
             v = f.variables[f'data{i}']
             buff = np.empty(shape = (1,), dtype = v.datatype)
             # post the request to read one part of the variable
-            req_id = v.iget_var(buff, index = index)
+            req_id = v.iget_var(buff, start)
             # track the reqeust ID for each read reqeust
             req_ids.append(req_id)
             # store the reference of variable values
@@ -97,7 +97,7 @@ class VariablesTestCase(unittest.TestCase):
             v = f.variables[f'data{i}']
             buff = np.empty(shape = (1,), dtype = v.datatype)
             # post the request to read a single element of values
-            v.iget_var(buff, index =  index)
+            v.iget_var(buff, start)
             # store the reference of variable values
             v_datas.append(buff)
 

--- a/test/tst_var_iput_var1.py
+++ b/test/tst_var_iput_var1.py
@@ -62,12 +62,12 @@ class VariablesTestCase(unittest.TestCase):
             v[:,::-1,:] = data
         # each process post 10 requests to write a single element
         req_ids = []
-        index = (rank, rank, rank)
+        start = (rank, rank, rank)
         value = np.int32(rank * 10 + 1)
         for i in range(num_reqs):
             v = f.variables[f'data{i}']
             # post the request to write a single element
-            req_id = v.iput_var(value, index = index)
+            req_id = v.iput_var(value, start)
             # track the reqeust ID for each write reqeust
             req_ids.append(req_id)
         f.end_indep()
@@ -83,7 +83,7 @@ class VariablesTestCase(unittest.TestCase):
         for i in range(num_reqs, num_reqs * 2):
             v = f.variables[f'data{i}']
             # post the request to write a single element
-            v.iput_var(value, index = index)
+            v.iput_var(value, start)
 
         # all processes commit all pending requests to the file at once using wait_all (collective i/o)
         f.wait_all(num = pnetcdf.NC_PUT_REQ_ALL)


### PR DESCRIPTION
Argument index is the argument start in `put_var`, `put_var_all`, `put_var` etc.