### PR TITLE
make varn APIs separated from var APIs

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -93,8 +93,8 @@ be found at the beginning of each file.
 
 * [put_varn_int.py](./put_varn_int.py)
   + This example shows how to use a single call of `Variable` method
-    `put_var()` to to write a sequence of requests with arbitrary array indices
-    and lengths.
+    `put_varn()` to write a sequence of subarray requests to a variable with
+    arbitrary array indices and lengths.
 
 * [transpose.py](./transpose.py)
   + This example shows how to use `Variable` method `put_var()` to write six 3D

--- a/examples/get_vara.py
+++ b/examples/get_vara.py
@@ -95,8 +95,8 @@ def pnetcdf_io(filename, file_format):
     if rank == 0 and verbose:
         print("variable attribute \"str_att_name\" of type text =", str_att)
 
-    # Get the length of the variable's attribute named "float_att_name"
-    float_att =  v.get_att("float_att_name")
+    # Get the variable's attribute named "float_att_name"
+    float_att = v.get_att("float_att_name")
 
     # set access pattern for reading subarray
     local_ny = global_ny

--- a/examples/put_varn_int.py
+++ b/examples/put_varn_int.py
@@ -4,8 +4,8 @@
 #
 
 """
-This example shows how to use a single call of `Variable` method `put_var()` to
-to write a sequence of requests with arbitrary array indices and lengths.
+This example shows how to use a single call of `Variable` method `put_varn()`
+to to write a sequence of requests with arbitrary array indices and lengths.
 
 To run:
   % mpiexec -n num_process python3 put_varn_int.py [test_file_name]
@@ -153,7 +153,7 @@ def pnetcdf_io(file_name, file_format):
     w_buf = np.full(w_len, rank, dtype=np.int32)
 
     # set the buffer pointers to different offsets to the I/O buffe
-    v.put_var_all(w_buf, start = starts, count = counts, num = num_reqs)
+    v.put_varn_all(w_buf, num = num_reqs, starts = starts, counts = counts)
 
     # close the file
     f.close()
@@ -187,7 +187,7 @@ if __name__ == "__main__":
     filename = args.dir
 
     if verbose and rank == 0:
-        print("{}: example of writing multiple variables in a call".format(os.path.basename(__file__)))
+        print("{}: example of writing multiple subarrays of a variable in a call".format(os.path.basename(__file__)))
 
     try:
         pnetcdf_io(filename, file_format)

--- a/src/pnetcdf/_File.pyx
+++ b/src/pnetcdf/_File.pyx
@@ -499,11 +499,10 @@ cdef class File:
 
         Operational mode: This method must be called while the file is in define mode.
         """
-
-
         cdef nc_type xtype
         xtype=-99
         _set_att(self, NC_GLOBAL, name, value, xtype=xtype)
+
 
     def get_att(self,name,encoding='utf-8'):
         """
@@ -519,13 +518,13 @@ cdef class File:
         :param name: Name of the attribute.
         :type name: str
 
-        :rtype: str
+        :rtype: str or numpy.ndarray
 
-        Operational mode: This method must be called while the file is in define mode.
+        Operational mode: This method can be called while the file is in either
+            define or data mode (collective or independent).
         """
-
-
         return _get_att(self, NC_GLOBAL, name, encoding=encoding)
+
 
     def __delattr__(self,name):
         # if it's a netCDF attribute, remove it

--- a/src/pnetcdf/_utils.pyx
+++ b/src/pnetcdf/_utils.pyx
@@ -296,7 +296,7 @@ cdef _get_att(file, int varid, name, encoding='utf-8'):
 
 
 cdef _get_att_names(int file_id, int varid):
-    # Private function to get all the attribute names in a group
+    # Private function to get all the attribute names of a variable
     cdef int ierr, numatts, n
     cdef char namstring[NC_MAX_NAME+1]
     if varid == NC_GLOBAL:

--- a/test/tst_var_bput_varn.py
+++ b/test/tst_var_bput_varn.py
@@ -4,13 +4,14 @@
 #
 
 """
-This example program is intended to illustrate the use of the pnetCDF python
-API. The program runs in non-blocking mode and makes a request to write a list
-of subarray of values to a variable into a netCDF variable of an opened netCDF
-file using bput_var method of `Variable` class. This method is a buffered
-version of bput_var and requires the user to attach an internal buffer of size
-equal to the sum of all requests using attach_buff method of `File` class. The
-library will internally invoke ncmpi_bput_vara and ncmpi_attach_buffer in C.
+This program test ibput_varn() method of `Variable` class, a nonblocking,
+buffered API, by making multiple calls to it to write to different NetCDF
+variables of an opened netCDF file.  Each call also writes to multiple
+subarrays of the same variable. This method is a buffered version of
+iput_varn() and requires the user to first attach an internal buffer of size
+equal to the sum of all requests using attach_buff() method of `File` class.
+The library will internally invoke ncmpi_bput_varn() and ncmpi_attach_buffer()
+in C.
 """
 
 import numpy as np
@@ -165,8 +166,8 @@ def run_test(format):
     for i in range(num_reqs):
         v = f.variables[f'data{i}']
         assert(f.inq_buff_size() - f.inq_buff_usage() > 0)
-        # post the request to write an array of values
-        req_id = v.bput_var(data, start = starts, count = counts, num = num_subarrays)
+        # post the request to write multiple subarrays
+        req_id = v.bput_varn(data, num_subarrays, starts, counts)
         # track the request ID for each write request
         req_ids.append(req_id)
 
@@ -182,7 +183,7 @@ def run_test(format):
     # post requests to write the 2nd half of variables w/o tracking req ids
     for i in range(num_reqs):
         v = f.variables[f'data{num_reqs + i}']
-        v.bput_var(data, start = starts, count = counts, num = num_subarrays)
+        v.bput_varn(data, num_subarrays, starts, counts)
 
     # commit the posted requests all at once using wait_all (collective i/o)
     f.wait_all(num = pnetcdf.NC_PUT_REQ_ALL)
@@ -218,3 +219,4 @@ if __name__ == '__main__':
         except BaseException as err:
             print("Error: type:", type(err), str(err))
             raise
+


### PR DESCRIPTION
1. the optional arguments of varn APIs are different from var
2. the dimensionality of starts, and counts are also different