### PR TITLE
Add python style of subarray I/O to example programs

### DIFF
--- a/examples/MNIST/Makefile
+++ b/examples/MNIST/Makefile
@@ -52,6 +52,7 @@ clean:
 	rm -f mnist_main.py
 	rm -f $(MNIST_DATASETS)
 	rm -f $(MNIST_DATASETS_GZ)
+	rm -rf __pycache__
 
 .PHONY: all check ptests clean
 

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -11,8 +11,6 @@ check_PROGRAMS = collective_write.py \
                  ghost_cell.py \
                  global_attribute.py \
                  hints.py \
-                 nonblocking_write_def.py \
-                 nonblocking_write.py \
                  put_varn_int.py \
                  transpose2D.py \
                  transpose.py \
@@ -28,10 +26,12 @@ OUTPUT_DIR = _tmp_output
 all:
 
 check: ptest4
+	cd nonblocking && make check
 	cd Pytorch_DDP && make check
 	cd MNIST && make check
 
 ptests: ptest3 ptest4 ptest8
+	cd nonblocking && make ptests
 	cd Pytorch_DDP && make ptests
 	cd MNIST && make ptests
 
@@ -61,6 +61,7 @@ ptest8:
 
 clean:
 	rm -rf ${OUTPUT_DIR}
+	cd nonblocking && make clean
 	cd Pytorch_DDP && make clean
 	cd MNIST && make clean
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,8 +1,8 @@
 # PnetCDF-python examples
 
 This directory contains example python programs that make use of PnetCDF to
-perform file I/O. Detailed description of each program and run instructions can
-be found at the beginning of each file.
+perform file I/O in parallel. Detailed description of each program and run
+instructions can be found at the beginning of each file.
 
 ---
 ### Running individual example programs
@@ -20,7 +20,7 @@ be found at the beginning of each file.
 ### Overview of Test Programs
 
 * [MNIST](./MNIST)
-  + This directory contains an example of
+  + A directory contains an example of
     [MNIST](https://github.com/pytorch/examples/tree/main/mnist),
     using Pytorch module `DistributedDataParallel` for parallel training and
     `PnetCDF-Python` for reading data from a NetCDF files.
@@ -28,6 +28,19 @@ be found at the beginning of each file.
 * [Pytorch_DDP](./Pytorch_DDP)
   + A directory contains examples that make use of Pytorch Distributed Data
     Parallel module to run python programs in parallel.
+
+* [nonblocking](./nonblocking)
+  + A directory contains examples that make use of nonblocking I/O APIs.
+    * [nonblocking_write.py](./nonblocking/nonblocking_write.py]) --
+      Similar to `collective_write.py`, this example uses nonblocking APIs
+      instead. It creates a netcdf file in CDF-5 format and writes a number of
+      3D integer non-record variables.
+
+    * [nonblocking_write_def.py](./nonblocking/nonblocking_write_def.py]) --
+      This example is the same as `nonblocking_write.py` expect all nonblocking
+      write requests (calls to `iput` and `bput`) are posted in define mode. It
+      creates a netcdf file in CDF-5 format and writes a number of 3D integer
+      non-record variables.
 
 * [collective_write.py](./collective_write.py)
   + This example writes multiple 3D subarrays to non-record variables of int
@@ -42,17 +55,6 @@ be found at the beginning of each file.
   + This example is the read counterpart of [put_vara.py](./put_vara.py), which
     shows how to use to `Variable` method get_var() read a 2D 4-byte integer
     array in parallel.
-
-* [nonblocking_write.py](./nonblocking_write.py)
-  + Similar to `collective_write.py`, this example uses nonblocking APIs
-    instead. It creates a netcdf file in CDF-5 format and writes a number of 3D
-    integer non-record variables.
-
-* [nonblocking_write_def.py](./nonblocking_write_def.py)
-  + This example is the same as `nonblocking_write.py` expect all nonblocking
-    write requests (calls to `iput` and `bput`) are posted in define mode. It
-    creates a netcdf file in CDF-5 format and writes a number of 3D integer
-    non-record variables.
 
 * [create_open.py](./create_open.py)
   + This example shows how to use `File` class constructor to create a NetCDF

--- a/examples/create_open.py
+++ b/examples/create_open.py
@@ -21,18 +21,6 @@ import sys, os, argparse
 from mpi4py import MPI
 import pnetcdf
 
-def parse_help():
-    help_flag = "-h" in sys.argv or "--help" in sys.argv
-    if help_flag and rank == 0:
-        help_text = (
-        "Usage: {} [-h] | [-q] [file_name]\n"
-            "       [-h] Print help\n"
-            "       [-q] Quiet mode (reports when fail)\n"
-            "       [filename] (Optional) output netCDF file name\n"
-        ).format(sys.argv[0])
-        print(help_text)
-    return help_flag
-
 def pnetcdf_io(filename):
 
     # create a new file using file clobber mode, i.e. flag "-w"
@@ -50,6 +38,18 @@ def pnetcdf_io(filename):
     # close the file
     f.close()
 
+
+def parse_help():
+    help_flag = "-h" in sys.argv or "--help" in sys.argv
+    if help_flag and rank == 0:
+        help_text = (
+        "Usage: {} [-h] | [-q] [file_name]\n"
+            "       [-h] Print help\n"
+            "       [-q] Quiet mode (reports when fail)\n"
+            "       [filename] (Optional) output netCDF file name\n"
+        ).format(sys.argv[0])
+        print(help_text)
+    return help_flag
 
 if __name__ == "__main__":
     comm = MPI.COMM_WORLD

--- a/examples/get_info.py
+++ b/examples/get_info.py
@@ -38,19 +38,6 @@ import numpy as np
 from mpi4py import MPI
 import pnetcdf
 
-def parse_help():
-    help_flag = "-h" in sys.argv or "--help" in sys.argv
-    if help_flag and rank == 0:
-        help_text = (
-            "Usage: {} [-h] | [-q] [file_name]\n"
-            "       [-h] Print help\n"
-            "       [-q] Quiet mode (reports when fail)\n"
-            "       [filename] (Optional) output netCDF file name\n"
-        ).format(sys.argv[0])
-        print(help_text)
-    return help_flag
-
-
 def print_info(info_used):
     nkeys = info_used.Get_nkeys()
     print("MPI File Info: nkeys =", nkeys)
@@ -82,6 +69,19 @@ def pnetcdf_io(filename):
 
     # close the file
     f.close()
+
+
+def parse_help():
+    help_flag = "-h" in sys.argv or "--help" in sys.argv
+    if help_flag and rank == 0:
+        help_text = (
+            "Usage: {} [-h] | [-q] [file_name]\n"
+            "       [-h] Print help\n"
+            "       [-q] Quiet mode (reports when fail)\n"
+            "       [filename] (Optional) output netCDF file name\n"
+        ).format(sys.argv[0])
+        print(help_text)
+    return help_flag
 
 
 if __name__ == "__main__":

--- a/examples/ghost_cell.py
+++ b/examples/ghost_cell.py
@@ -66,62 +66,38 @@ from mpi4py import MPI
 import pnetcdf
 
 
-def parse_help():
-    help_flag = "-h" in sys.argv or "--help" in sys.argv
-    if help_flag and rank == 0:
-        help_text = (
-            "Usage: {} [-h] | [-q] [file_name]\n"
-            "       [-h] Print help\n"
-            "       [-q] Quiet mode (reports when fail)\n"
-            "       [-k format] file format: 1 for CDF-1, 2 for CDF-2, 5 for CDF-5\n"
-            "       [-l len] size of each dimension of the local array\n"
-            "       [filename] (Optional) output netCDF file name\n"
-        ).format(sys.argv[0])
-        print(help_text)
-    return help_flag
-
-
 def pnetcdf_io(filename, file_format, length):
 
     count = [length, length + 1]
     psizes = MPI.Compute_dims(nprocs, 2)
 
+    nghosts = 2
+
     if verbose and rank == 0:
-        print("psizes=", psizes[0], psizes[1])
+        print("number of MPI processes =", nprocs)
+        print("number of ghost cells =", nghosts)
+        print("psizes=", psizes)
 
     # set global array sizes
     gsizes = np.zeros(2, dtype=np.int64)
     gsizes[0] = length * psizes[0]  # global array size
     gsizes[1] = (length + 1) * psizes[1]
     if verbose and rank == 0:
-        print("global variable shape:", gsizes[0], gsizes[1])
+        print("global variable shape:", gsizes)
 
     # find its local rank IDs along each dimension
     local_rank = np.zeros(2, dtype=np.int32)
     local_rank[0] = rank // psizes[1]
     local_rank[1] = rank % psizes[1]
     if verbose:
-        print("rank {}: dim rank= {} {}".format(rank, local_rank[0], local_rank[1]))
+        print("rank ",rank,": local_rank = ", local_rank)
 
     # set subarray access pattern
     count = np.array([length, length + 1], dtype=np.int64)
     start = np.array([local_rank[0] * count[0], local_rank[1] * count[1]],
                       dtype=np.int64)
     if verbose:
-        print("start= {} {} count= {} {}".format(start[0], start[1], count[0], count[1]))
-
-   # allocate and initialize buffer with ghost cells on both ends of each dim
-    nghosts = 2
-    bufsize = (count[0] + 2 * nghosts) * (count[1] + 2 * nghosts)
-    buf = np.empty(bufsize, dtype=np.int32)
-    for i in range(count[0] + 2 * nghosts):
-        for j in range(count[1] + 2 * nghosts):
-            if nghosts <= i < count[0] + nghosts and \
-               nghosts <= j < count[1] + nghosts:
-                buf[i * (count[1] + 2 * nghosts) + j] = rank
-            else:
-                # set values of all ghost cells to -8
-                buf[i * (count[1] + 2 * nghosts) + j] = -8
+        print("rank ",rank,": start = ",start," count =", count)
 
     # Create the file
     f = pnetcdf.File(filename = filename,
@@ -140,17 +116,37 @@ def pnetcdf_io(filename, file_format, length):
     # Exit the define mode
     f.enddef()
 
-    # set imap pattern for local buffer
-    imap = np.zeros(2, dtype=np.int64)
-    imap[1] = 1
-    imap[0] = count[1] + 2 * nghosts
-    buf_ptr = buf[nghosts * (count[1] + 2 * nghosts + 1):]
+    # allocate and initialize buffer with ghost cells on both ends of each dim
+    buf = np.empty([2*nghosts+count[0], 2*nghosts+count[1]], dtype=np.int32)
+    buf.fill(-8)
+
+    # keep contents of ghost cells to -8, all others 'rank'
+    buf[nghosts:nghosts+count[0], nghosts:nghosts+count[1]].fill(rank)
 
     # Write data to the variable
-    var.put_var_all(buf_ptr, start = start, count = count, imap = imap)
+    end = np.add(start, count)
+    var[start[0]:end[0], start[1]:end[1]] = buf[nghosts:nghosts+count[0], nghosts:nghosts+count[1]]
+
+    # Equivalently, below uses function call
+    var.put_var_all(buf[nghosts:nghosts+count[0], nghosts:nghosts+count[1]], start = start, count = count)
 
     # Close the file
     f.close()
+
+
+def parse_help():
+    help_flag = "-h" in sys.argv or "--help" in sys.argv
+    if help_flag and rank == 0:
+        help_text = (
+            "Usage: {} [-h] | [-q] [file_name]\n"
+            "       [-h] Print help\n"
+            "       [-q] Quiet mode (reports when fail)\n"
+            "       [-k format] file format: 1 for CDF-1, 2 for CDF-2, 5 for CDF-5\n"
+            "       [-l len] size of each dimension of the local array\n"
+            "       [filename] (Optional) output netCDF file name\n"
+        ).format(sys.argv[0])
+        print(help_text)
+    return help_flag
 
 
 if __name__ == "__main__":

--- a/examples/global_attribute.py
+++ b/examples/global_attribute.py
@@ -32,19 +32,6 @@ from mpi4py import MPI
 import pnetcdf
 
 
-def parse_help():
-    help_flag = "-h" in sys.argv or "--help" in sys.argv
-    if help_flag and rank == 0:
-        help_text = (
-            "Usage: {} [-h] | [-q] [file_name]\n"
-            "       [-h] Print help\n"
-            "       [-q] Quiet mode (reports when fail)\n"
-            "       [-k format] file format: 1 for CDF-1, 2 for CDF-2, 5 for CDF-5\n"
-            "       [filename] (Optional) output netCDF file name\n"
-        ).format(sys.argv[0])
-        print(help_text)
-    return help_flag
-
 def pnetcdf_io(filename, file_format):
     digit = np.int16([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
 
@@ -67,14 +54,21 @@ def pnetcdf_io(filename, file_format):
     str_att = comm.bcast(str_att, root=0)
 
     # write a global attribute
-    f.put_att('history',str_att)
+    f.history = str_att
+
     if rank == 0 and verbose:
         print(f'writing global attribute "history" of text {str_att}')
 
+    # Equivalently, below uses function call
+    f.put_att('history',str_att)
+
     # add another global attribute named "digits": an array of short type
-    f.put_att('digits', digit)
+    f.digits = digit
     if rank == 0 and verbose:
         print("writing global attribute \"digits\" of 10 short integers")
+
+    # Equivalently, below uses function call
+    f.put_att('digits', digit)
 
     # Close the file
     f.close()
@@ -106,6 +100,19 @@ def pnetcdf_io(filename, file_format):
     # close the file
     f.close()
 
+
+def parse_help():
+    help_flag = "-h" in sys.argv or "--help" in sys.argv
+    if help_flag and rank == 0:
+        help_text = (
+            "Usage: {} [-h] | [-q] [file_name]\n"
+            "       [-h] Print help\n"
+            "       [-q] Quiet mode (reports when fail)\n"
+            "       [-k format] file format: 1 for CDF-1, 2 for CDF-2, 5 for CDF-5\n"
+            "       [filename] (Optional) output netCDF file name\n"
+        ).format(sys.argv[0])
+        print(help_text)
+    return help_flag
 
 if __name__ == "__main__":
     comm = MPI.COMM_WORLD

--- a/examples/nonblocking/Makefile
+++ b/examples/nonblocking/Makefile
@@ -1,0 +1,49 @@
+#
+# Copyright (C) 2024, Northwestern University and Argonne National Laboratory
+# See COPYRIGHT notice in top-level directory.
+#
+
+check_PROGRAMS = nonblocking_write_def.py \
+                 nonblocking_write.py
+
+
+TESTS_ENVIRONMENT  = export check_PROGRAMS="${check_PROGRAMS}";
+TESTS_ENVIRONMENT += export PNETCDF_DIR="${PNETCDF_DIR}";
+
+OUTPUT_DIR = _tmp_output
+
+all:
+
+check: ptest4
+
+ptests: ptest3 ptest4 ptest8
+
+ptest3:
+	@mkdir -p ${OUTPUT_DIR}
+	@echo "======================================================================"
+	@echo "    examples: Parallel testing on 3 MPI processes"
+	@echo "======================================================================"
+	@${TESTS_ENVIRONMENT} export NPROC=3; ./parallel_run.sh ${OUTPUT_DIR} || exit 1
+	@echo ""
+
+ptest4:
+	@mkdir -p ${OUTPUT_DIR}
+	@echo "======================================================================"
+	@echo "    examples: Parallel testing on 4 MPI processes"
+	@echo "======================================================================"
+	@${TESTS_ENVIRONMENT} export NPROC=4; ./parallel_run.sh ${OUTPUT_DIR} || exit 1
+	@echo ""
+
+ptest8:
+	@mkdir -p ${OUTPUT_DIR}
+	@echo "======================================================================"
+	@echo "    examples: Parallel testing on 8 MPI processes"
+	@echo "======================================================================"
+	@${TESTS_ENVIRONMENT} export NPROC=8; ./parallel_run.sh ${OUTPUT_DIR} || exit 1
+	@echo ""
+
+clean:
+	rm -rf ${OUTPUT_DIR}
+
+.PHONY: all check ptests ptest3 ptest4 ptest8 clean
+

--- a/examples/nonblocking/nonblocking_write.py
+++ b/examples/nonblocking/nonblocking_write.py
@@ -4,14 +4,13 @@
 #
 
 """
-This example is the same as nonblocking_write.py expect all nonblocking
-write requests (calls to iput and bput) are posted in define mode.
+This example is similar to collective_write.py but using nonblocking APIs.
 It creates a netcdf file in CDF-5 format and writes a number of
 3D integer non-record variables. The measured write bandwidth is reported
 at the end. Usage: (for example)
 
 To run:
-  mpiexec -n num_processes nonblocking_write_def.py [filename] [len]
+  mpiexec -n num_processes nonblocking_write.py [filename] [len]
 
   where len decides the size of each local array, which is len x len x len.
   So, each non-record variable is of size len*len*len * nprocs * sizeof(int)
@@ -19,7 +18,7 @@ To run:
   block-block-block fashion. Below is an example standard output from
   command:
 
-  mpiexec -n 32 python3 nonblocking_write_def.py tmp/test1.nc -l 100
+  mpiexec -n 32 python3 nonblocking_write_.py tmp/test1.nc 100
 
   MPI hint: cb_nodes        = 2
   MPI hint: cb_buffer_size  = 16777216
@@ -37,21 +36,7 @@ import numpy as np
 from mpi4py import MPI
 import pnetcdf
 
-def parse_help():
-    help_flag = "-h" in sys.argv or "--help" in sys.argv
-    if help_flag and rank == 0:
-        help_text = (
-            "Usage: {} [-h] | [-q] [file_name]\n"
-            "       [-h] Print help\n"
-            "       [-q] Quiet mode (reports when fail)\n"
-            "       [-l len] size of each dimension of the local array\n"
-            "       [filename] (Optional) output netCDF file name\n"
-        ).format(sys.argv[0])
-        print(help_text)
-    return help_flag
-
-
-def pnetcdf_io(file_name, length):
+def pnetcdf_io(filename, length):
     NDIMS = 3
     NUM_VARS = 10
 
@@ -59,7 +44,7 @@ def pnetcdf_io(file_name, length):
         print("Number of variables = ", NUM_VARS)
         print("Number of dimensions = ", NDIMS)
 
-    # set subarray access pattern
+    # set up subarray access pattern
     start = np.zeros(NDIMS, dtype=np.int32)
     count = np.zeros(NDIMS, dtype=np.int32)
     gsizes = np.zeros(NDIMS, dtype=np.int32)
@@ -102,22 +87,29 @@ def pnetcdf_io(file_name, length):
         var = f.def_var("var{}".format(i), pnetcdf.NC_INT, dims)
         vars.append(var)
 
-    # Write one variable at a time
-    for i in range(NUM_VARS):
-        vars[i].iput_var(buf[i], start = start, count = count)
-
-    # exit define mode and enter data mode
+    # Exit the define mode
     f.enddef()
 
-    # commit posted nonblocking requests
-    f.wait_all(num = pnetcdf.NC_REQ_ALL)
+    # Write one variable at a time, using iput APIs
+    reqs = []
+    for i in range(NUM_VARS):
+        req_id = vars[i].iput_var(buf[i], start = start, count = count)
+        reqs.append(req_id)
 
-    # use nonblocking bput APIs
-    # First, calculate the amount of space required
+    # commit posted noblocking requests
+    req_errs = [None] * NUM_VARS
+    f.wait_all(NUM_VARS, reqs, req_errs)
+
+    # check errors
+    for i in range(NUM_VARS):
+        if pnetcdf.strerrno(req_errs[i]) != "NC_NOERR":
+            print(f"Error on request {i}:",  pnetcdf.strerror(req_errs[i]))
+
+    # call bput APIs, first calculate space needed
     bbufsize = bufsize * NUM_VARS * np.dtype(np.int32).itemsize
     f.attach_buff(bbufsize)
 
-    # call bput for writing to one variable at a time
+    # Write one variable at a time, using bput APIs
     reqs = []
     for i in range(NUM_VARS):
         req_id = vars[i].bput_var(buf[i], start = start, count = count)
@@ -136,8 +128,22 @@ def pnetcdf_io(file_name, length):
     # detach the temporary buffer
     f.detach_buff()
 
-    # close the file
+    # Close the file
     f.close()
+
+
+def parse_help():
+    help_flag = "-h" in sys.argv or "--help" in sys.argv
+    if help_flag and rank == 0:
+        help_text = (
+            "Usage: {} [-h] | [-q] [file_name]\n"
+            "       [-h] Print help\n"
+            "       [-q] Quiet mode (reports when fail)\n"
+            "       [-l len] size of each dimension of the local array\n"
+            "       [filename] (Optional) output netCDF file name\n"
+        ).format(sys.argv[0])
+        print(help_text)
+    return help_flag
 
 
 if __name__ == "__main__":
@@ -161,13 +167,12 @@ if __name__ == "__main__":
     verbose = False if args.q else True
 
     length = 10
-    if args.l and int(args.l) > 0:
-       length = int(args.l)
+    if args.l and int(args.l) > 0: length = int(args.l)
 
     filename = args.dir
 
     if verbose and rank == 0:
-        print("{}: example of nonblocking APIs in define mode".format(os.path.basename(__file__)))
+        print("{}: example of calling nonblocking write APIs".format(os.path.basename(__file__)))
 
     try:
         pnetcdf_io(filename, length)

--- a/examples/nonblocking/parallel_run.sh
+++ b/examples/nonblocking/parallel_run.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+#
+# Copyright (C) 2024, Northwestern University and Argonne National Laboratory
+# See COPYRIGHT notice in top-level directory.
+#
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+# Get the directory containing this script
+if test "x$NPROC" = x ; then
+    NPROC=4
+fi
+
+# get output folder from command line
+if test "$#" -gt 0 ; then
+   args=("$@")
+   OUT_DIR="${args[0]}"
+   # check if output folder exists
+   if ! test -d $OUT_DIR ; then
+      echo "Error: output folder \"$OUT_DIR\" does not exist."
+      exit 1
+   fi
+else
+   # output folder is not set at command line, use current folder
+   OUT_DIR="."
+fi
+# echo "OUT_DIR=$OUT_DIR"
+
+MPI4PY_VERSION=`python -c "import mpi4py; print(mpi4py.__version__)"`
+MPI4PY_VERSION_MAJOR=`echo ${MPI4PY_VERSION} | cut -d. -f1`
+# echo "MPI4PY_VERSION=$MPI4PY_VERSION"
+# echo "MPI4PY_VERSION_MAJOR=$MPI4PY_VERSION_MAJOR"
+
+TEST_FLEXIBLE_API=no
+if test "x$PNETCDF_DIR" != x ; then
+   PNETCDF_C_VERSION=`$PNETCDF_DIR/bin/pnetcdf-config --version | cut -d' ' -f2`
+   V_MAJOR=`echo ${PNETCDF_C_VERSION} | cut -d. -f1`
+   V_MINOR=`echo ${PNETCDF_C_VERSION} | cut -d. -f2`
+   V_SUB=`echo ${PNETCDF_C_VERSION} | cut -d. -f3`
+   VER_NUM=$((V_MAJOR*1000000 + V_MINOR*1000 + V_SUB))
+   if test $VER_NUM -gt 1013000 ; then
+      TEST_FLEXIBLE_API=yes
+   fi
+fi
+
+# test PnetCDF flexible APIs only when PnetCDF-C >= 1.13.1 or mpi4py < 4
+if test $MPI4PY_VERSION_MAJOR -lt 4 ; then
+   TEST_FLEXIBLE_API=yes
+fi
+
+for prog in $check_PROGRAMS; do
+   if test "x$TEST_FLEXIBLE_API" = xno &&
+      test "x$prog" = "xflexible_api.py" ; then
+      TETS_PROGS+=" flexible_api.py"
+      printf '%-60s' "Testing $prog"
+      echo " ---- SKIP"
+      continue
+   fi
+
+   printf '%-60s' "Testing $prog"
+
+   CMD="mpiexec -n $NPROC python $prog -q $OUT_DIR/${prog%.*}.nc"
+   $CMD
+   status=$?
+   if [ $status -ne 0 ]; then
+      echo " ---- FAIL"
+   else
+      echo " ---- PASS"
+   fi
+done
+

--- a/examples/put_varn_int.py
+++ b/examples/put_varn_int.py
@@ -42,20 +42,6 @@ from mpi4py import MPI
 import pnetcdf
 
 
-def parse_help():
-    help_flag = "-h" in sys.argv or "--help" in sys.argv
-    if help_flag and rank == 0:
-        help_text = (
-            "Usage: {} [-h] | [-q] [file_name]\n"
-            "       [-h] Print help\n"
-            "       [-q] Quiet mode (reports when fail)\n"
-            "       [-k format] file format: 1 for CDF-1, 2 for CDF-2, 5 for CDF-5\n"
-            "       [filename] (Optional) output netCDF file name\n"
-        ).format(sys.argv[0])
-        print(help_text)
-    return help_flag
-
-
 def pnetcdf_io(file_name, file_format):
     NY = 4
     NX = 10
@@ -157,6 +143,20 @@ def pnetcdf_io(file_name, file_format):
 
     # close the file
     f.close()
+
+
+def parse_help():
+    help_flag = "-h" in sys.argv or "--help" in sys.argv
+    if help_flag and rank == 0:
+        help_text = (
+            "Usage: {} [-h] | [-q] [file_name]\n"
+            "       [-h] Print help\n"
+            "       [-q] Quiet mode (reports when fail)\n"
+            "       [-k format] file format: 1 for CDF-1, 2 for CDF-2, 5 for CDF-5\n"
+            "       [filename] (Optional) output netCDF file name\n"
+        ).format(sys.argv[0])
+        print(help_text)
+    return help_flag
 
 
 if __name__ == "__main__":

--- a/examples/transpose.py
+++ b/examples/transpose.py
@@ -29,21 +29,6 @@ import numpy as np
 from mpi4py import MPI
 import pnetcdf
 
-def parse_help():
-    help_flag = "-h" in sys.argv or "--help" in sys.argv
-    if help_flag and rank == 0:
-        help_text = (
-            "Usage: {} [-h] | [-q] [file_name]\n"
-            "       [-h] Print help\n"
-            "       [-q] Quiet mode (reports when fail)\n"
-            "       [-k format] file format: 1 for CDF-1, 2 for CDF-2, 5 for CDF-5\n"
-            "       [-l len] size of each dimension of the local array\n"
-            "       [filename] (Optional) output netCDF file name\n"
-        ).format(sys.argv[0])
-        print(help_text)
-    return help_flag
-
-
 def pnetcdf_io(filename, file_format, length):
 
     NDIMS = 3
@@ -162,6 +147,21 @@ def pnetcdf_io(filename, file_format, length):
 
     # Close the file
     f.close()
+
+
+def parse_help():
+    help_flag = "-h" in sys.argv or "--help" in sys.argv
+    if help_flag and rank == 0:
+        help_text = (
+            "Usage: {} [-h] | [-q] [file_name]\n"
+            "       [-h] Print help\n"
+            "       [-q] Quiet mode (reports when fail)\n"
+            "       [-k format] file format: 1 for CDF-1, 2 for CDF-2, 5 for CDF-5\n"
+            "       [-l len] size of each dimension of the local array\n"
+            "       [filename] (Optional) output netCDF file name\n"
+        ).format(sys.argv[0])
+        print(help_text)
+    return help_flag
 
 
 if __name__ == "__main__":

--- a/examples/transpose2D.py
+++ b/examples/transpose2D.py
@@ -51,20 +51,6 @@ import numpy as np
 from mpi4py import MPI
 import pnetcdf
 
-def parse_help():
-    help_flag = "-h" in sys.argv or "--help" in sys.argv
-    if help_flag and rank == 0:
-        help_text = (
-            "Usage: {} [-h] | [-q] [file_name]\n"
-            "       [-h] Print help\n"
-            "       [-q] Quiet mode (reports when fail)\n"
-            "       [-k format] file format: 1 for CDF-1, 2 for CDF-2, 5 for CDF-5\n"
-            "       [-l len] size of each dimension of the local array\n"
-            "       [filename] (Optional) output netCDF file name\n"
-        ).format(sys.argv[0])
-        print(help_text)
-    return help_flag
-
 def pnetcdf_io(filename, file_format, length):
     NDIMS = 2
 
@@ -146,6 +132,20 @@ def pnetcdf_io(filename, file_format, length):
     # Close the file
     f.close()
 
+
+def parse_help():
+    help_flag = "-h" in sys.argv or "--help" in sys.argv
+    if help_flag and rank == 0:
+        help_text = (
+            "Usage: {} [-h] | [-q] [file_name]\n"
+            "       [-h] Print help\n"
+            "       [-q] Quiet mode (reports when fail)\n"
+            "       [-k format] file format: 1 for CDF-1, 2 for CDF-2, 5 for CDF-5\n"
+            "       [-l len] size of each dimension of the local array\n"
+            "       [filename] (Optional) output netCDF file name\n"
+        ).format(sys.argv[0])
+        print(help_text)
+    return help_flag
 
 if __name__ == "__main__":
     comm = MPI.COMM_WORLD

--- a/test/Makefile
+++ b/test/Makefile
@@ -83,6 +83,7 @@ ptest8:
 
 clean:
 	rm -rf ${OUTPUT_DIR}
+	rm -rf __pycache__
 
 .PHONY: all check ptests ptest3 ptest4 ptest8 clean
 


### PR DESCRIPTION
For writing attributes,
```
    # python subarray style
    var.float_att_name = float_att

    # Equivalently, below uses function call
    var.put_att("float_att_name", float_att)
```

For variables,
```
    # python subarray style
    end = [start[i] + count[i] for i in range(2)]
    var[start[0]:end[0], start[1]:end[1]] = buf

    # Equivalently, below uses function call
    var.put_var_all(buf, start = start, count = count)
```

In addition, move example programs of nonblocking APIs to folder examples/nonblocking
