### PR TITLE
add instructions for quick install

### DIFF
--- a/.github/workflows/pnetcdf_c_master.yml
+++ b/.github/workflows/pnetcdf_c_master.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
-      MPICH_VERSION: 4.2.0
+      MPICH_VERSION: 4.2.2
       MPICH_DIR: ${{ github.workspace }}/mpich-install
       PNETCDF_VERSION: repo
       PNETCDF_DIR: ${{ github.workspace }}/PnetCDF-install

--- a/.github/workflows/pnetcdf_c_official.yml
+++ b/.github/workflows/pnetcdf_c_official.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
-      MPICH_VERSION: 4.2.0
+      MPICH_VERSION: 4.2.2
       MPICH_DIR: ${{ github.workspace }}/mpich-install
       PNETCDF_VERSION: 1.13.0
       PNETCDF_DIR: ${{ github.workspace }}/PnetCDF-install

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ scalable I/O performance.
 * [PnetCDF C library](https://github.com/Parallel-netCDF/PnetCDF), built with shared libraries.
 
 ### Quick Installation
-* Make sure have a working MPI and pnetcdf-C software and then use pip to install pnetcdf-Python library from PyPI
+* Make sure you have a working MPI and pnetcdf-C software and then use pip to install pnetcdf-Python library from PyPI
   ```
   CC=/path/to/mpicc PNETCDF_DIR=/path/to/pnetcdf/dir/ pip install pnetcdf
   ```

--- a/README.md
+++ b/README.md
@@ -12,11 +12,16 @@ scalable I/O performance.
 ### Software Dependencies
 * Python 3.9 or later.
 * [numpy](http://www.numpy.org/) Python package.
-* MPI C library and Python package, [mpi4py](https://mpi4py.readthedocs.io/en/stable/install.html).
-* [PnetCDF C library](https://github.com/Parallel-netCDF/PnetCDF), built with shared libraries.
+* MPI C library and Python package,
+  [mpi4py](https://mpi4py.readthedocs.io/en/stable/install.html).
+  + Note when using mpi4py 4.0 and MPICH, MPICH version 4.2.2 and later is
+    required.
+* [PnetCDF C library](https://github.com/Parallel-netCDF/PnetCDF), built with
+  shared libraries.
 
 ### Quick Installation
-* Make sure you have a working MPI and pnetcdf-C software and then use pip to install pnetcdf-Python library from PyPI
+* Make sure you have a working MPI and PnetCDF-C software installed.
+* Run pip command below to install PnetCDF-Python library from PyPI:
   ```
   CC=/path/to/mpicc PNETCDF_DIR=/path/to/pnetcdf/dir/ pip install pnetcdf
   ```

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ scalable I/O performance.
 * MPI C library and Python package, [mpi4py](https://mpi4py.readthedocs.io/en/stable/install.html).
 * [PnetCDF C library](https://github.com/Parallel-netCDF/PnetCDF), built with shared libraries.
 
+### Quick Installation
+* Make sure have a working MPI and pnetcdf-C software and then use pip to install pnetcdf-Python library from PyPI
+  ```
+  CC=/path/to/mpicc PNETCDF_DIR=/path/to/pnetcdf/dir/ pip install pnetcdf
+  ```
+
 ### Developer Installation
 * Clone this GitHub repository
 * Required software for developer installation:

--- a/docs/source/installation/install.rst
+++ b/docs/source/installation/install.rst
@@ -9,9 +9,11 @@ Quick Install
 Software Requirements
  - PnetCDF C library (built with shared libraries) and MPI C library
 
-Make sure you have a working MPI and pnetcdf-C software and then use pip to install pnetcdf-Python library from PyPI
-.. code-block:: bash
-    $ CC=/path/to/mpicc PNETCDF_DIR=/path/to/pnetcdf/dir/ pip install pnetcdf
+Install PnetCDF-python library from PyPI
+ .. code-block:: bash
+
+     $ CC=/path/to/mpicc PNETCDF_DIR=/path/to/pnetcdf/dir/ pip install pnetcdf
+
 
 Install from Source
 ============================================

--- a/docs/source/installation/install.rst
+++ b/docs/source/installation/install.rst
@@ -9,7 +9,7 @@ Quick Install
 Software Requirements
  - PnetCDF C library (built with shared libraries) and MPI C library
 
-Make sure have a working MPI and pnetcdf-C software and then use pip to install pnetcdf-Python library from PyPI
+Make sure you have a working MPI and pnetcdf-C software and then use pip to install pnetcdf-Python library from PyPI
 .. code-block:: bash
     $ CC=/path/to/mpicc PNETCDF_DIR=/path/to/pnetcdf/dir/ pip install pnetcdf
 

--- a/docs/source/installation/install.rst
+++ b/docs/source/installation/install.rst
@@ -6,8 +6,12 @@ Installation
 Quick Install
 ===================================
 
-Quick installation via pip install is currently unavailable as this library has not yet been uploaded to PyPI. 
-Please follow building from source instructions provided below to set up the library.
+Software Requirements
+ - PnetCDF C library (built with shared libraries) and MPI C library
+
+Make sure have a working MPI and pnetcdf-C software and then use pip to install pnetcdf-Python library from PyPI
+.. code-block:: bash
+    $ CC=/path/to/mpicc PNETCDF_DIR=/path/to/pnetcdf/dir/ pip install pnetcdf
 
 Install from Source
 ============================================


### PR DESCRIPTION
* Add quick install instructions, i.e. install from PyPi, in README.md and user guide
* When using mpi4py 4.0 and MPICH, MPICH version 4.2.2 and later is required.
  This is because MPI 4.0's large-count feature is only properly supported by
  MPICH starting from 4.2.2.