### PR TITLE
Support OpenMPI

### DIFF
--- a/.github/workflows/openmpi.yml
+++ b/.github/workflows/openmpi.yml
@@ -1,0 +1,116 @@
+name: Using OpenMPI
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.txt'
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.txt'
+
+jobs:
+  build-linux:
+    name: Python (${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      OPENMPI_VERSION: 5.0.7
+      OPENMPI_DIR: ${{ github.workspace }}/ompi-install
+      PNETCDF_VERSION: 1.14.0
+      PNETCDF_DIR: ${{ github.workspace }}/PnetCDF-install
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+    steps:
+
+    - uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install Ubuntu Dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install m4
+
+    - name: Build OPENMPI
+      run: |
+        echo "Install OpenMPI ${OPENMPI_VERSION} in $OPENMPI_DIR"
+        VER_MAJOR=${OPENMPI_VERSION%.*}
+        rm -rf OPENMPI ; mkdir OPENMPI ; cd OPENMPI
+        wget -q https://download.open-mpi.org/release/open-mpi/v${VER_MAJOR}/openmpi-${OPENMPI_VERSION}.tar.gz
+        gzip -dc openmpi-${OPENMPI_VERSION}.tar.gz | tar -xf -
+        cd openmpi-${OPENMPI_VERSION}
+        ./configure --prefix=$OPENMPI_DIR \
+                    --with-io-romio-flags="--with-file-system=ufs" \
+                    --with-hwloc=internal \
+                    --with-pmix=internal \
+                    --with-libevent=internal \
+                    --disable-mpi-fortran \
+                    CC=gcc
+        make -s LIBTOOLFLAGS=--silent V=1 -j 4 install > qout 2>&1
+        make -s -j 4 distclean >> qout 2>&1
+
+    - name: Build PnetCDF-C official release
+      run: |
+        echo "Download and build PnetCDF-C release version ${PNETCDF_VERSION}"
+        wget -q https://parallel-netcdf.github.io/Release/pnetcdf-${PNETCDF_VERSION}.tar.gz
+        tar -xzf pnetcdf-${PNETCDF_VERSION}.tar.gz
+        pushd pnetcdf-${PNETCDF_VERSION}
+        ./configure --prefix=$PNETCDF_DIR \
+                    --silent \
+                    --enable-shared \
+                    --enable-debug \
+                    --disable-fortran \
+                    --disable-cxx \
+                    --with-mpi=$OPENMPI_DIR
+        make -s LIBTOOLFLAGS=--silent V=1 -j 4 install > qout 2>&1
+        make -s -j 4 distclean >> qout 2>&1
+        popd
+
+    - name: Install python dependencies via pip
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        pip install numpy cython cftime pytest twine check-manifest
+        export MPICC=$OPENMPI_DIR/bin/mpicc
+        pip install mpi4py
+        pip install torch torchvision
+
+    - name: Install PnetCDF-Python
+      run: |
+        export CC=$OPENMPI_DIR/bin/mpicc
+        pip install --verbose --no-build-isolation -e .
+
+    - name: Test PnetCDF-Python
+      run: |
+        export PATH=${OPENMPI_DIR}/bin:${PATH}
+        make ptests TESTMPIRUN="${OPENMPI_DIR}/bin/mpiexec --oversubscribe"
+
+    - name: Re-install PnetCDF-Python from source distribution
+      run: |
+        pip uninstall -y pnetcdf
+        make install-clean
+        export CC=$OPENMPI_DIR/bin/mpicc
+        python setup.py sdist
+        pip install --verbose dist/pnetcdf-*.tar.gz
+
+    - name: Test PnetCDF-Python
+      run: |
+        export PATH=${OPENMPI_DIR}/bin:${PATH}
+        make ptests TESTMPIRUN="${OPENMPI_DIR}/bin/mpiexec --oversubscribe"
+
+#   - name: Tarball
+#     run: |
+#       export PATH=${NETCDF_DIR}/bin:${PATH}
+#       python setup.py --version
+#       check-manifest --version
+#       check-manifest --verbose
+#       pip wheel . -w dist --no-deps
+#       twine check dist/*

--- a/.github/workflows/pnetcdf_c_master.yml
+++ b/.github/workflows/pnetcdf_c_master.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
-      MPICH_VERSION: 4.2.2
+      MPICH_VERSION: 4.3.0
       MPICH_DIR: ${{ github.workspace }}/mpich-install
       PNETCDF_VERSION: repo
       PNETCDF_DIR: ${{ github.workspace }}/PnetCDF-install
@@ -93,7 +93,7 @@ jobs:
     - name: Test PnetCDF-Python
       run: |
         export PATH=${MPICH_DIR}/bin:${PATH}
-        make ptests
+        make ptests TESTMPIRUN="${MPICH_DIR}/bin/mpiexec"
 
     - name: Re-install PnetCDF-Python from source distribution
       run: |
@@ -106,7 +106,7 @@ jobs:
     - name: Test PnetCDF-Python
       run: |
         export PATH=${MPICH_DIR}/bin:${PATH}
-        make ptests
+        make ptests TESTMPIRUN="${MPICH_DIR}/bin/mpiexec"
 #   - name: Tarball
 #     run: |
 #       export PATH=${NETCDF_DIR}/bin:${PATH}

--- a/.github/workflows/pnetcdf_c_master.yml
+++ b/.github/workflows/pnetcdf_c_master.yml
@@ -23,6 +23,10 @@ jobs:
       MPICH_DIR: ${{ github.workspace }}/mpich-install
       PNETCDF_VERSION: repo
       PNETCDF_DIR: ${{ github.workspace }}/PnetCDF-install
+      AUTOCONF_VERSION: 2.71
+      AUTOMAKE_VERSION: 1.17
+      LIBTOOL_VERSION: 2.5.4
+      M4_VERSION: 1.4.19
 
     strategy:
       matrix:
@@ -40,6 +44,43 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install automake autoconf libtool libtool-bin m4
+
+    - name: Build GNU autotools
+      run: |
+        export PATH="${GITHUB_WORKSPACE}/AUTOTOOLS/bin:${PATH}"
+        export LD_LIBRARY_PATH="${GITHUB_WORKSPACE}/AUTOTOOLS/lib:${LD_LIBRARY_PATH}"
+        cd ${GITHUB_WORKSPACE}
+        wget -q https://ftp.gnu.org/gnu/m4/m4-${M4_VERSION}.tar.gz
+        gzip -dc m4-${M4_VERSION}.tar.gz | tar -xf -
+        cd m4-${M4_VERSION}
+        ./configure --prefix=${GITHUB_WORKSPACE}/AUTOTOOLS \
+                    --silent
+        make -s -j 8 install > qout 2>&1
+        make -s -j 8 distclean >> qout 2>&1
+        cd ${GITHUB_WORKSPACE}
+        wget -q https://ftp.gnu.org/gnu/autoconf/autoconf-${AUTOCONF_VERSION}.tar.gz
+        gzip -dc autoconf-${AUTOCONF_VERSION}.tar.gz | tar -xf -
+        cd autoconf-${AUTOCONF_VERSION}
+        ./configure --prefix=${GITHUB_WORKSPACE}/AUTOTOOLS \
+                    --silent
+        make -s -j 8 install > qout 2>&1
+        make -s -j 8 distclean >> qout 2>&1
+        cd ${GITHUB_WORKSPACE}
+        wget -q https://ftp.gnu.org/gnu/automake/automake-${AUTOMAKE_VERSION}.tar.gz
+        gzip -dc automake-${AUTOMAKE_VERSION}.tar.gz | tar -xf -
+        cd automake-${AUTOMAKE_VERSION}
+        ./configure --prefix=${GITHUB_WORKSPACE}/AUTOTOOLS \
+                    --silent
+        make -s -j 8 install > qout 2>&1
+        make -s -j 8 distclean >> qout 2>&1
+        cd ${GITHUB_WORKSPACE}
+        wget -q https://ftp.gnu.org/gnu/libtool/libtool-${LIBTOOL_VERSION}.tar.gz
+        gzip -dc libtool-${LIBTOOL_VERSION}.tar.gz | tar -xf -
+        cd libtool-${LIBTOOL_VERSION}
+        ./configure --prefix=${GITHUB_WORKSPACE}/AUTOTOOLS \
+                    --silent
+        make -s -j 8 install > qout 2>&1
+        make -s -j 8 distclean >> qout 2>&1
 
     - name: Build MPICH
       run: |
@@ -63,6 +104,12 @@ jobs:
       run: |
         echo "Build PnetCDF-C from its master branch"
         cd ${GITHUB_WORKSPACE}
+        export PATH="${GITHUB_WORKSPACE}/AUTOTOOLS/bin:${PATH}"
+        export LD_LIBRARY_PATH="${GITHUB_WORKSPACE}/AUTOTOOLS/lib:${LD_LIBRARY_PATH}"
+        m4 --version
+        autoconf --version
+        automake --version
+        libtool --version
         git clone -q https://github.com/Parallel-NetCDF/PnetCDF.git
         pushd PnetCDF
         autoreconf -i

--- a/.github/workflows/pnetcdf_c_official.yml
+++ b/.github/workflows/pnetcdf_c_official.yml
@@ -19,9 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
-      MPICH_VERSION: 4.2.2
+      MPICH_VERSION: 4.3.0
       MPICH_DIR: ${{ github.workspace }}/mpich-install
-      PNETCDF_VERSION: 1.13.0
+      PNETCDF_VERSION: 1.14.0
       PNETCDF_DIR: ${{ github.workspace }}/PnetCDF-install
     strategy:
       matrix:
@@ -91,7 +91,7 @@ jobs:
     - name: Test PnetCDF-Python
       run: |
         export PATH=${MPICH_DIR}/bin:${PATH}
-        make ptests
+        make ptests TESTMPIRUN="${MPICH_DIR}/bin/mpiexec"
 
     - name: Re-install PnetCDF-Python from source distribution
       run: |
@@ -104,7 +104,7 @@ jobs:
     - name: Test PnetCDF-Python
       run: |
         export PATH=${MPICH_DIR}/bin:${PATH}
-        make ptests
+        make ptests TESTMPIRUN="${MPICH_DIR}/bin/mpiexec"
 
 #   - name: Tarball
 #     run: |

--- a/README.md
+++ b/README.md
@@ -40,8 +40,16 @@ scalable I/O performance.
   export PNETCDF_DIR=/path/to/pnetcdf/dir
   pip install --no-build-isolation -e .
   ```
-* Testing -- Command `"make check"` tests all the programs available in folders
-  ["test/"](./test) and ["examples/"](./examples).
+* Testing
+  + Command `"make check"` tests all the programs available in folders
+  ["test/"](./test) and ["examples/"](./examples) by running one MPI process.
+  + Command `"make ptests"` tests all the programs by running more than one MPI
+    process.
+  + Note when using OpenMPI, use command below.
+    ```
+    make check  TESTMPIRUN="/path/to/OpenMPI/bin/mpirun --oversubscribe"
+    make ptests TESTMPIRUN="/path/to/OpenMPI/bin/mpirun --oversubscribe"
+    ```
 
 ### Additional Resources
 * [Example python programs](./examples#pnetcdf-python-examples) available in

--- a/examples/MNIST/Makefile
+++ b/examples/MNIST/Makefile
@@ -7,6 +7,8 @@ check_PROGRAMS = mnist_main.py
 
 MNIST_URL = https://raw.githubusercontent.com/pytorch/examples/main/mnist/main.py
 
+TESTMPIRUN = $(shell dirname ${CC})/mpirun
+
 all:
 
 mnist_main.py:
@@ -45,7 +47,7 @@ ptests check: mnist_main.py
 	@echo "======================================================================"
 	@echo "    examples/MNIST: Parallel testing on 4 MPI processes"
 	@echo "======================================================================"
-	@mpiexec -n 4 python mnist_main.py --batch-size 4 --test-batch-size 2 --epochs 3 --input-file mnist_images.nc
+	@${TESTMPIRUN} -n 4 python mnist_main.py --batch-size 4 --test-batch-size 2 --epochs 3 --input-file mnist_images.nc
 	@echo ""
 
 clean:

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -17,9 +17,10 @@ check_PROGRAMS = collective_write.py \
                  put_var.py \
                  get_var.py
 
-
+TESTMPIRUN = $(shell dirname ${CC})/mpirun
 TESTS_ENVIRONMENT  = export check_PROGRAMS="${check_PROGRAMS}";
 TESTS_ENVIRONMENT += export PNETCDF_DIR="${PNETCDF_DIR}";
+TESTS_ENVIRONMENT += export TESTMPIRUN="$(TESTMPIRUN)";
 
 OUTPUT_DIR = _tmp_output
 

--- a/examples/Pytorch_DDP/Makefile
+++ b/examples/Pytorch_DDP/Makefile
@@ -6,8 +6,10 @@
 check_PROGRAMS = torch_ddp_skeleton.py
 
 
+TESTMPIRUN = $(shell dirname ${CC})/mpirun
 TESTS_ENVIRONMENT  = export check_PROGRAMS="${check_PROGRAMS}";
 TESTS_ENVIRONMENT += export PNETCDF_DIR="${PNETCDF_DIR}";
+TESTS_ENVIRONMENT += export TESTMPIRUN="$(TESTMPIRUN)";
 
 OUTPUT_DIR = _tmp_output
 

--- a/examples/Pytorch_DDP/parallel_run.sh
+++ b/examples/Pytorch_DDP/parallel_run.sh
@@ -31,7 +31,7 @@ for prog in $check_PROGRAMS; do
    printf '%-60s' "Testing $prog"
 
    if test $prog = "torch_ddp_skeleton.py" ; then
-      CMD="mpiexec -n $NPROC python $prog -q"
+      CMD="${TESTMPIRUN} -n $NPROC python $prog -q"
    fi
    $CMD
    status=$?

--- a/examples/nonblocking/Makefile
+++ b/examples/nonblocking/Makefile
@@ -7,9 +7,10 @@ check_PROGRAMS = nonblocking_write_def.py \
                  nonblocking_write.py \
                  nonblocking_read.py
 
-
+TESTMPIRUN = $(shell dirname ${CC})/mpirun
 TESTS_ENVIRONMENT  = export check_PROGRAMS="${check_PROGRAMS}";
 TESTS_ENVIRONMENT += export PNETCDF_DIR="${PNETCDF_DIR}";
+TESTS_ENVIRONMENT += export TESTMPIRUN="$(TESTMPIRUN)";
 
 OUTPUT_DIR = _tmp_output
 

--- a/examples/nonblocking/parallel_run.sh
+++ b/examples/nonblocking/parallel_run.sh
@@ -61,9 +61,9 @@ for prog in $check_PROGRAMS; do
    printf '%-60s' "Testing $prog"
 
    if test "x$prog" = "xnonblocking_read.py" ; then
-      CMD="mpiexec -n $NPROC python $prog -q $OUT_DIR/nonblocking_write.nc"
+      CMD="${TESTMPIRUN} -n $NPROC python $prog -q $OUT_DIR/nonblocking_write.nc"
    else
-      CMD="mpiexec -n $NPROC python $prog -q $OUT_DIR/${prog%.*}.nc"
+      CMD="${TESTMPIRUN} -n $NPROC python $prog -q $OUT_DIR/${prog%.*}.nc"
    fi
    # echo "$CMD"
 

--- a/examples/parallel_run.sh
+++ b/examples/parallel_run.sh
@@ -61,9 +61,9 @@ for prog in $check_PROGRAMS; do
    printf '%-60s' "Testing $prog"
 
    if test $prog = "get_var.py" ; then
-      CMD="mpiexec -n $NPROC python $prog -q $OUT_DIR/put_var.nc"
+      CMD="${TESTMPIRUN} -n $NPROC python $prog -q $OUT_DIR/put_var.nc"
    else
-      CMD="mpiexec -n $NPROC python $prog -q $OUT_DIR/${prog%.*}.nc"
+      CMD="${TESTMPIRUN} -n $NPROC python $prog -q $OUT_DIR/${prog%.*}.nc"
    fi
    $CMD
    status=$?

--- a/src/pnetcdf/_Variable.pyx
+++ b/src/pnetcdf/_Variable.pyx
@@ -28,7 +28,6 @@ cimport numpy
 numpy.import_array()
 
 
-ctypedef MPI.Datatype Datatype
 
 
 cdef class Variable:
@@ -699,7 +698,7 @@ cdef class Variable:
             self._put(dataput,a,b,c)
 
 
-    def _put_var1(self, value, tuple index, bufcount, Datatype buftype, collective = True):
+    def _put_var1(self, value, tuple index, bufcount, MPI.Datatype buftype, collective = True):
         cdef int ierr, ndims
         cdef size_t *indexp
         cdef MPI_Offset buffcount
@@ -735,7 +734,7 @@ cdef class Variable:
         _check_err(ierr)
         free(indexp)
 
-    def _put_var(self, ndarray data, bufcount, Datatype buftype, collective = True):
+    def _put_var(self, ndarray data, bufcount, MPI.Datatype buftype, collective = True):
         cdef int ierr, ndims
         cdef MPI_Offset buffcount
         cdef MPI_Datatype bufftype
@@ -765,7 +764,7 @@ cdef class Variable:
                                      PyArray_DATA(data), buffcount, bufftype)
         _check_err(ierr)
 
-    def _put_vara(self, start, count, ndarray data, bufcount, Datatype buftype, collective = True):
+    def _put_vara(self, start, count, ndarray data, bufcount, MPI.Datatype buftype, collective = True):
         cdef int ierr, ndims
         cdef MPI_Offset buffcount
         cdef MPI_Datatype bufftype
@@ -802,7 +801,7 @@ cdef class Variable:
                                      PyArray_DATA(data), buffcount, bufftype)
         _check_err(ierr)
 
-    def _put_varn(self, ndarray data, num, starts, counts=None, bufcount=None, buftype=None, collective = True):
+    def _put_varn(self, ndarray data, num, starts, counts=None, bufcount=None, MPI.Datatype buftype=None, collective = True):
         cdef int ierr, ndims
         cdef MPI_Offset buffcount
         cdef MPI_Datatype bufftype
@@ -862,7 +861,7 @@ cdef class Variable:
                                       bufftype)
         _check_err(ierr)
 
-    def put_varn_all(self, data, num, starts, counts=None, bufcount=None, buftype=None):
+    def put_varn_all(self, data, num, starts, counts=None, bufcount=None, MPI.Datatype buftype=None):
         """
         put_varn_all(self, data, num, starts, counts=None, bufcount=None, buftype=None)
 
@@ -967,7 +966,7 @@ cdef class Variable:
         self._put_varn(data, num, starts, counts, bufcount = bufcount,
                        buftype = buftype, collective = True)
 
-    def put_varn(self, data, num, starts, counts=None, bufcount=None, buftype=None):
+    def put_varn(self, data, num, starts, counts=None, bufcount=None, MPI.Datatype buftype=None):
         """
         put_varn(self, data, num, starts, counts=None, bufcount=None, buftype=None)
 
@@ -979,7 +978,7 @@ cdef class Variable:
         self._put_varn(data, num, starts, counts, bufcount = bufcount,
                        buftype = buftype, collective = False)
 
-    def iput_varn(self, data, num, starts, counts=None, bufcount=None, buftype=None):
+    def iput_varn(self, data, num, starts, counts=None, bufcount=None, MPI.Datatype buftype=None):
         """
         iput_varn(self, data, num, starts, counts=None, bufcount=None, buftype=None)
 
@@ -1008,7 +1007,7 @@ cdef class Variable:
         return self._iput_varn(data, num, starts, counts, bufcount, buftype,
                                buffered=False)
 
-    def bput_varn(self, data, num, starts, counts=None, bufcount=None, buftype=None):
+    def bput_varn(self, data, num, starts, counts=None, bufcount=None, MPI.Datatype buftype=None):
         """
         bput_varn(self, data, num, starts, counts=None, bufcount=None, buftype=None)
 
@@ -1035,7 +1034,7 @@ cdef class Variable:
         """
         return self._iput_varn(data, num, starts, counts, bufcount, buftype, buffered=True)
 
-    def _put_vars(self, start, count, stride, ndarray data, bufcount, Datatype buftype, collective = True):
+    def _put_vars(self, start, count, stride, ndarray data, bufcount, MPI.Datatype buftype, collective = True):
         cdef int ierr, ndims
         cdef MPI_Offset buffcount
         cdef MPI_Datatype bufftype
@@ -1078,7 +1077,7 @@ cdef class Variable:
         _check_err(ierr)
 
 
-    def _put_varm(self, ndarray data, start, count, stride, imap, bufcount, Datatype buftype, collective = True):
+    def _put_varm(self, ndarray data, start, count, stride, imap, bufcount, MPI.Datatype buftype, collective = True):
         cdef int ierr, ndims
         cdef MPI_Offset buffcount
         cdef MPI_Datatype bufftype
@@ -1131,7 +1130,7 @@ cdef class Variable:
 
 
 
-    def put_var_all(self, data, start=None, count=None, stride=None, imap=None, bufcount=None, buftype=None):
+    def put_var_all(self, data, start=None, count=None, stride=None, imap=None, bufcount=None, MPI.Datatype buftype=None):
         """
         put_var_all(self, data, start=None, count=None, stride=None, imap=None, bufcount=None, buftype=None)
 
@@ -1423,7 +1422,7 @@ cdef class Variable:
         free(countp)
         free(stridep)
 
-    def _get_var1(self, ndarray buff, index, bufcount, Datatype buftype, collective = True):
+    def _get_var1(self, ndarray buff, index, bufcount, MPI.Datatype buftype, collective = True):
         cdef int ierr, ndims
         cdef size_t *indexp
         cdef MPI_Offset buffcount
@@ -1453,7 +1452,7 @@ cdef class Variable:
         free(indexp)
 
 
-    def _get_var(self, ndarray buff, bufcount, Datatype buftype, collective = True):
+    def _get_var(self, ndarray buff, bufcount, MPI.Datatype buftype, collective = True):
         cdef int ierr, ndims
         cdef MPI_Offset buffcount
         cdef MPI_Datatype bufftype
@@ -1479,7 +1478,7 @@ cdef class Variable:
         _check_err(ierr)
 
 
-    def _get_vara(self, ndarray buff, start, count, bufcount, Datatype buftype, collective = True):
+    def _get_vara(self, ndarray buff, start, count, bufcount, MPI.Datatype buftype, collective = True):
         cdef int ierr, ndims
         cdef MPI_Offset buffcount
         cdef MPI_Datatype bufftype
@@ -1513,7 +1512,7 @@ cdef class Variable:
 
         _check_err(ierr)
 
-    def _get_varn(self, ndarray data, num, starts, counts, bufcount, Datatype buftype, collective = True):
+    def _get_varn(self, ndarray data, num, starts, counts, bufcount, MPI.Datatype buftype, collective = True):
         cdef int ierr, ndims
         cdef MPI_Offset buffcount
         cdef MPI_Datatype bufftype
@@ -1569,7 +1568,7 @@ cdef class Variable:
 
         _check_err(ierr)
 
-    def _get_vars(self, ndarray buff, start, count, stride, bufcount, Datatype buftype, collective = True):
+    def _get_vars(self, ndarray buff, start, count, stride, bufcount, MPI.Datatype buftype, collective = True):
         cdef int ierr, ndims
         cdef MPI_Offset buffcount
         cdef MPI_Datatype bufftype
@@ -1606,7 +1605,7 @@ cdef class Variable:
 
         _check_err(ierr)
 
-    def _get_varm(self, ndarray buff, start, count, stride, imap, bufcount, Datatype buftype, collective = True):
+    def _get_varm(self, ndarray buff, start, count, stride, imap, bufcount, MPI.Datatype buftype, collective = True):
         cdef int ierr, ndims
         cdef MPI_Offset buffcount
         cdef MPI_Datatype bufftype
@@ -2058,7 +2057,7 @@ cdef class Variable:
         else:
             return data
 
-    def _iput_var(self, ndarray data, bufcount, Datatype buftype, buffered = False):
+    def _iput_var(self, ndarray data, bufcount, MPI.Datatype buftype, buffered = False):
         cdef int ierr, ndims
         cdef MPI_Offset buffcount
         cdef MPI_Datatype bufftype
@@ -2090,7 +2089,7 @@ cdef class Variable:
         _check_err(ierr)
         return request
 
-    def _iput_var1(self, value, index, bufcount, Datatype buftype, buffered=False):
+    def _iput_var1(self, value, index, bufcount, MPI.Datatype buftype, buffered=False):
         cdef int ierr, ndims
         cdef size_t *indexp
         cdef MPI_Offset buffcount
@@ -2127,7 +2126,7 @@ cdef class Variable:
         _check_err(ierr)
         return request
 
-    def _iput_vara(self, start, count, ndarray data, bufcount, Datatype buftype, buffered=False):
+    def _iput_vara(self, start, count, ndarray data, bufcount, MPI.Datatype buftype, buffered=False):
         cdef int ierr, ndims
         cdef MPI_Offset buffcount
         cdef MPI_Datatype bufftype
@@ -2166,7 +2165,7 @@ cdef class Variable:
         _check_err(ierr)
         return request
 
-    def _iput_vars(self, start, count, stride, ndarray data, bufcount, Datatype buftype, buffered=False):
+    def _iput_vars(self, start, count, stride, ndarray data, bufcount, MPI.Datatype buftype, buffered=False):
         cdef int ierr, ndims
         cdef MPI_Offset buffcount
         cdef MPI_Datatype bufftype
@@ -2206,7 +2205,7 @@ cdef class Variable:
         _check_err(ierr)
         return request
 
-    def _iput_varn(self, ndarray data, num, starts, counts, bufcount, Datatype buftype, buffered=False):
+    def _iput_varn(self, ndarray data, num, starts, counts, bufcount, MPI.Datatype buftype, buffered=False):
         cdef int ierr, ndims
         cdef MPI_Offset buffcount
         cdef MPI_Datatype bufftype
@@ -2270,7 +2269,7 @@ cdef class Variable:
         _check_err(ierr)
         return request
 
-    def _iput_varm(self, ndarray data, start, count, stride, imap, bufcount, Datatype buftype, buffered=False):
+    def _iput_varm(self, ndarray data, start, count, stride, imap, bufcount, MPI.Datatype buftype, buffered=False):
         cdef int ierr, ndims
         cdef MPI_Offset buffcount
         cdef MPI_Datatype bufftype
@@ -2405,7 +2404,7 @@ cdef class Variable:
         else:
             raise ValueError("Invalid input arguments for iput_var")
 
-    def _iget_var(self, ndarray data, bufcount, Datatype buftype):
+    def _iget_var(self, ndarray data, bufcount, MPI.Datatype buftype):
         cdef int ierr, ndims
         cdef MPI_Offset buffcount
         cdef MPI_Datatype bufftype
@@ -2425,7 +2424,7 @@ cdef class Variable:
         return request
 
 
-    def _iget_var1(self, ndarray buff, index, bufcount, Datatype buftype):
+    def _iget_var1(self, ndarray buff, index, bufcount, MPI.Datatype buftype):
         cdef int ierr, ndims
         cdef size_t *indexp
         cdef MPI_Offset buffcount
@@ -2452,7 +2451,7 @@ cdef class Variable:
         return request
 
 
-    def _iget_vara(self, ndarray data, start, count, bufcount, Datatype buftype):
+    def _iget_vara(self, ndarray data, start, count, bufcount, MPI.Datatype buftype):
         cdef int ierr, ndims
         cdef MPI_Offset buffcount
         cdef MPI_Datatype bufftype
@@ -2481,7 +2480,7 @@ cdef class Variable:
         _check_err(ierr)
         return request
 
-    def _iget_vars(self, ndarray buff, start, count, stride, bufcount, Datatype buftype):
+    def _iget_vars(self, ndarray buff, start, count, stride, bufcount, MPI.Datatype buftype):
         cdef int ierr, ndims
         cdef MPI_Offset buffcount
         cdef MPI_Datatype bufftype
@@ -2513,7 +2512,7 @@ cdef class Variable:
         _check_err(ierr)
         return request
 
-    def iget_varn(self, ndarray data, num, starts, counts=None, bufcount=None, Datatype buftype=None):
+    def iget_varn(self, ndarray data, num, starts, counts=None, bufcount=None, MPI.Datatype buftype=None):
         """
         iget_varn(self, data, num, starts, counts=None, bufcount=None, buftype=None)
 
@@ -2585,7 +2584,7 @@ cdef class Variable:
         _check_err(ierr)
         return request
 
-    def _iget_varm(self, ndarray buff, start, count, stride, imap, bufcount, Datatype buftype):
+    def _iget_varm(self, ndarray buff, start, count, stride, imap, bufcount, MPI.Datatype buftype):
         cdef int ierr, ndims
         cdef MPI_Offset buffcount
         cdef MPI_Datatype bufftype

--- a/src/pnetcdf/_utils.pyx
+++ b/src/pnetcdf/_utils.pyx
@@ -44,17 +44,17 @@ _nptonctype  = {'S1' : NC_CHAR_C,
                 'f4' : NC_FLOAT_C,
                 'f8' : NC_DOUBLE_C}
 
-_nptompitype = {'S1' : MPI_CHAR,
-                'i1' : MPI_BYTE,
-                'u1' : MPI_UNSIGNED_CHAR,
-                'i2' : MPI_SHORT,
-                'u2' : MPI_UNSIGNED_SHORT,
-                'i4' : MPI_INT,
-                'u4' : MPI_UNSIGNED,
-                'i8' : MPI_LONG_LONG,
-                'u8' : MPI_UNSIGNED_LONG_LONG,
-                'f4' : MPI_FLOAT,
-                'f8' : MPI_DOUBLE}
+_nptompitype = {'S1' : MPI.CHAR,
+                'i1' : MPI.BYTE,
+                'u1' : MPI.UNSIGNED_CHAR,
+                'i2' : MPI.SHORT,
+                'u2' : MPI.UNSIGNED_SHORT,
+                'i4' : MPI.INT,
+                'u4' : MPI.UNSIGNED,
+                'i8' : MPI.LONG_LONG,
+                'u8' : MPI.UNSIGNED_LONG_LONG,
+                'f4' : MPI.FLOAT,
+                'f8' : MPI.DOUBLE}
 
 
 """_nptompitype = {'S1' : MPI_CHAR,

--- a/test/Makefile
+++ b/test/Makefile
@@ -50,7 +50,9 @@ check_PROGRAMS = tst_atts.py \
                  tst_wait.py \
                  tst_libver.py
 
+TESTMPIRUN = $(shell dirname ${CC})/mpirun
 TESTS_ENVIRONMENT = export check_PROGRAMS="${check_PROGRAMS}";
+TESTS_ENVIRONMENT += export TESTMPIRUN="$(TESTMPIRUN)";
 OUTPUT_DIR = _tmp_output
 
 all:

--- a/test/parallel_run.sh
+++ b/test/parallel_run.sh
@@ -31,9 +31,9 @@ for prog in ${check_PROGRAMS} ; do
    printf '%-60s' "Testing $prog "
 
    if test $prog = "tst_libver.py" ; then
-      CMD="mpiexec -n $NPROC python $prog -q"
+      CMD="${TESTMPIRUN} -n $NPROC python $prog -q"
    else
-      CMD="mpiexec -n $NPROC python $prog $OUT_DIR"
+      CMD="${TESTMPIRUN} -n $NPROC python $prog $OUT_DIR"
    fi
    $CMD
    status=$?


### PR DESCRIPTION
We tested PnetCDF-Python using MPICH only.
This PR adds support for using OpenMPI.

Note some data objects defined in mpich are different between MPICH and OpenMPI.
For example, MPI_CHAR is a C constant in MPICH and enurm in OpenMPI.
MPI_Comm is an int in MPICH and struct pointer in OpenMPI.