### PR TITLE
doc: add index table

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -41,6 +41,11 @@ netCDF files.
    api/attribute_api
    api/function_api
 
+Appendix
+--------
+
+* :ref:`genindex`
+
 .. toctree::
    :maxdepth: 1
    :caption: Copyright


### PR DESCRIPTION
In the readthedocs user guide, add index table generated by sphinx.